### PR TITLE
 fix(admin): dev server only exposes host for ipv4

### DIFF
--- a/admin/webpack.config.ts
+++ b/admin/webpack.config.ts
@@ -121,7 +121,6 @@ const config = (env: unknown, argv: Argv): webpack.Configuration => {
             static: {
                 directory: path.join(__dirname, "public"),
             },
-            host: "0.0.0.0",
             port: Number(process.env.ADMIN_PORT || 8001),
             allowedHosts: "all",
             compress: true,


### PR DESCRIPTION
since node17 localhost dns is resolved with ipv6 which causes wait-on to not getting ready for admin-codegens

https://github.com/jeffbski/wait-on/issues/133