### PR TITLE
Remove docker-compose.js

### DIFF
--- a/dev-pm.config.js
+++ b/dev-pm.config.js
@@ -2,7 +2,7 @@ module.exports = {
     scripts: [
         {
             name: "docker",
-            script: "node docker-compose.js",
+            script: "docker compose up",
             group: "api",
         },
         {

--- a/docker-compose.js
+++ b/docker-compose.js
@@ -1,9 +1,0 @@
-const { spawn, exec } = require("child_process");
-
-spawn("docker-compose", ["up"], { stdio: "inherit" });
-
-process.on("SIGINT", function () {
-    exec(`docker-compose down`, function (error) {
-        process.exit(error ? 1 : 0);
-    });
-});


### PR DESCRIPTION
The custom docker-compose.js script occasionally caused the dev-pm shutdown to get stuck waiting for Docker to stop (despite Docker being already stopped). Using `docker compose up` directly in dev-pm resolves the issue. We therefore remove the docker-compose.js script.