### PR TITLE
add translatable title for headline block

### DIFF
--- a/admin/src/common/blocks/HeadlineBlock.tsx
+++ b/admin/src/common/blocks/HeadlineBlock.tsx
@@ -25,7 +25,7 @@ export const HeadlineBlock = createCompositeBlock({
     blocks: {
         headline: {
             block: RichTextBlock,
-            title: "Headline",
+            title: <FormattedMessage id="headlineBlock.title" defaultMessage="Headline" />,
         },
         level: {
             block: createCompositeSetting<HeadlineBlockData["level"]>({


### PR DESCRIPTION
this is often copied (without translation) in new projects and new blocks, because the block is used as a starting point.