### PR TITLE
add moduleNameMapper to resolve src path in test files

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -37,6 +37,9 @@
             "json",
             "ts"
         ],
+        "moduleNameMapper": {
+            "@src/(.*)": "<rootDir>/$1"
+        },
         "rootDir": "src",
         "testEnvironment": "node",
         "testRegex": ".*\\.spec\\.ts$",


### PR DESCRIPTION
Without the setting moduleNameMapper jest can't resolve "@src/..." imports and fails with the following error:
```
Cannot find module '@src/products/products.acl.service' from 'products/products.acl.service.spec.ts'

      1 | import { Test, TestingModule } from "@nestjs/testing";
      2 | import { CurrentUser } from "@src/auth/current-user";
    > 3 | import { ProductsAclService } from "@src/products/products.acl.service";
        | ^
      4 |
      5 | import { Product } from "./entities/product.entity";
      6 |

      at Resolver.resolveModule (../node_modules/jest-resolve/build/resolver.js:324:11)
      at Object.<anonymous> (products/products.acl.service.spec.ts:3:1)
```

The moduleNameMapper resolves the @src alias.
https://jestjs.io/docs/configuration#modulenamemapper-objectstring-string--arraystring


Why is this needed, because under normal circumstances, you don't need that. But if for example you assert for enums or to arrange the input for a test you normally import via @src and don't create a relative import.
An example could be:
```ts
import { EntityType } from "@src/test-entity/entity-type.enum"

it("should correctly calculate the sum of two testEntities", () => {
    // Arrange
    const testEntity: TestEntity = new TestEntity();
    testEntity.type = EntityType.FIX;
    testEntity.value = 5;

    const testEntity2: TestEntity = new TestEntity();
    testEntity2.type = EntityType.FIX;
    testEntity2.value = 10;

    // Act
    const result = service.calculateSum(testEntity, testEntity2);

    // Assert
    expect(result).toBe(50);
});
```