### PR TITLE
Replace CircularProgress with Loading

### DIFF
--- a/admin/src/common/ContentScopeProvider.tsx
+++ b/admin/src/common/ContentScopeProvider.tsx
@@ -1,4 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
+import { Loading } from "@comet/admin";
 import { Domain as DomainIcon, Language as LanguageIcon } from "@comet/admin-icons";
 import {
     ContentScopeConfigProps,
@@ -12,7 +13,6 @@ import {
     useContentScopeConfig as useContentScopeConfigLibrary,
     useSitesConfig,
 } from "@comet/cms-admin";
-import { CircularProgress } from "@mui/material";
 import React from "react";
 
 import { GQLCurrentUserScopeQuery, GQLCurrentUserScopeQueryVariables } from "./ContentScopeProvider.generated";
@@ -62,7 +62,7 @@ export const ContentScopeProvider: React.FC<Pick<ContentScopeProviderProps, "chi
     const sitesConfig = useSitesConfig();
     const { loading, data } = useQuery<GQLCurrentUserScopeQuery, GQLCurrentUserScopeQueryVariables>(currentUserQuery);
 
-    if (loading || !data) return <CircularProgress />;
+    if (loading || !data) return <Loading behavior="fillPageHeight" />;
 
     const allowedUserDomains = data.currentUser.domains;
 

--- a/admin/src/documents/links/EditLink.tsx
+++ b/admin/src/documents/links/EditLink.tsx
@@ -1,9 +1,9 @@
 import { gql } from "@apollo/client";
-import { MainContent, RouterPrompt, RouterTab, RouterTabs, Toolbar, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
+import { Loading, MainContent, RouterPrompt, RouterTab, RouterTabs, Toolbar, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
 import { ArrowLeft } from "@comet/admin-icons";
 import { AdminComponentRoot } from "@comet/blocks-admin";
 import { createUsePage, EditPageLayout, PageName } from "@comet/cms-admin";
-import { CircularProgress, IconButton } from "@mui/material";
+import { IconButton } from "@mui/material";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import * as React from "react";
 import { useIntl } from "react-intl";
@@ -68,7 +68,7 @@ export const EditLink: React.FC<Props> = ({ id }) => {
     });
 
     if (loading) {
-        return <CircularProgress />;
+        return <Loading behavior="fillPageHeight" />;
     }
 
     if (!linkState) return <></>;

--- a/admin/src/documents/pages/EditPage.tsx
+++ b/admin/src/documents/pages/EditPage.tsx
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client";
-import { MainContent, RouterPrompt, Toolbar, ToolbarActions, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
+import { Loading, MainContent, RouterPrompt, Toolbar, ToolbarActions, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
 import { ArrowLeft, Preview } from "@comet/admin-icons";
 import { AdminComponentRoot, AdminTabLabel } from "@comet/blocks-admin";
 import {
@@ -12,7 +12,7 @@ import {
     useCmsBlockContext,
     useSiteConfig,
 } from "@comet/cms-admin";
-import { Button, CircularProgress, IconButton, Stack } from "@mui/material";
+import { Button, IconButton, Stack } from "@mui/material";
 import { useContentScope } from "@src/common/ContentScopeProvider";
 import { GQLPageTreeNodeCategory } from "@src/graphql.generated";
 import * as React from "react";
@@ -98,7 +98,7 @@ export const EditPage: React.FC<Props> = ({ id, category }) => {
     if (!pageState) return <></>;
 
     if (loading) {
-        return <CircularProgress />;
+        return <Loading behavior="fillPageHeight" />;
     }
 
     return (

--- a/admin/src/products/ProductForm.tsx
+++ b/admin/src/products/ProductForm.tsx
@@ -4,13 +4,14 @@ import {
     FinalForm,
     FinalFormInput,
     FinalFormSaveSplitButton,
+    Loading,
     MainContent,
     Toolbar,
     ToolbarActions,
     ToolbarBackButton,
     ToolbarFillSpace,
 } from "@comet/admin";
-import { Card, CardContent, CircularProgress } from "@mui/material";
+import { Card, CardContent } from "@mui/material";
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 
@@ -62,7 +63,7 @@ export function ProductForm({ id }: FormProps): React.ReactElement {
     }
 
     if (loading) {
-        return <CircularProgress />;
+        return <Loading behavior="fillPageHeight" />;
     }
 
     const initialValues: Partial<FormValues> = data?.product ?? {};


### PR DESCRIPTION
depends on https://github.com/vivid-planet/comet-starter/pull/28

Replaces all usages of `<CircularProgress />` with the new `<Loading />` component