### PR TITLE
Display linebreaks in RTE correctly

### DIFF
--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -25,61 +25,61 @@ const defaultRenderers: Renderers = {
      */
     blocks: {
         // Paragraph
-        unstyled: (children, { keys }) => children.map((child, idx) => <StyledComponent key={keys[idx]}>{child}</StyledComponent>),
+        unstyled: (children, { keys }) => children.map((child, idx) => <Text key={keys[idx]}>{child}</Text>),
         // Headlines
         "header-one": (children, { keys }) =>
             children.map((child, idx) => (
-                <StyledComponent as="h1" key={keys[idx]}>
+                <Text as="h1" key={keys[idx]}>
                     {child}
-                </StyledComponent>
+                </Text>
             )),
         "header-two": (children, { keys }) =>
             children.map((child, idx) => (
-                <StyledComponent as="h2" key={keys[idx]}>
+                <Text as="h2" key={keys[idx]}>
                     {child}
-                </StyledComponent>
+                </Text>
             )),
         "header-three": (children, { keys }) =>
             children.map((child, idx) => (
-                <StyledComponent as="h3" key={keys[idx]}>
+                <Text as="h3" key={keys[idx]}>
                     {child}
-                </StyledComponent>
+                </Text>
             )),
         "header-four": (children, { keys }) =>
             children.map((child, idx) => (
-                <StyledComponent as="h4" key={keys[idx]}>
+                <Text as="h4" key={keys[idx]}>
                     {child}
-                </StyledComponent>
+                </Text>
             )),
         "header-five": (children, { keys }) =>
             children.map((child, idx) => (
-                <StyledComponent as="h5" key={keys[idx]}>
+                <Text as="h5" key={keys[idx]}>
                     {child}
-                </StyledComponent>
+                </Text>
             )),
         "header-six": (children, { keys }) =>
             children.map((child, idx) => (
-                <StyledComponent as="h6" key={keys[idx]}>
+                <Text as="h6" key={keys[idx]}>
                     {child}
-                </StyledComponent>
+                </Text>
             )),
         // List
         // or depth for nested lists
         "unordered-list-item": (children, { depth, keys }) => (
             <ul key={keys[keys.length - 1]} className={`ul-level-${depth}`}>
                 {children.map((child, index) => (
-                    <StyledComponent as="li" key={keys[index]}>
+                    <Text as="li" key={keys[index]}>
                         {child}
-                    </StyledComponent>
+                    </Text>
                 ))}
             </ul>
         ),
         "ordered-list-item": (children, { depth, keys }) => (
             <ol key={keys.join("|")} className={`ol-level-${depth}`}>
                 {children.map((child, index) => (
-                    <StyledComponent as="li" key={keys[index]}>
+                    <Text as="li" key={keys[index]}>
                         {child}
-                    </StyledComponent>
+                    </Text>
                 ))}
             </ol>
         ),
@@ -120,12 +120,11 @@ export function hasDraftContent(draftContent: RawDraftContentState): boolean {
     return !(draftContent.blocks.length == 1 && draftContent.blocks[0].text === "");
 }
 
-const StyledComponent = styled.p`
+const Text = styled.p`
     white-space: pre-line;
 
+    // Workaround empty paragraphs used as spacing
     &:empty {
-        margin-bottom: 0;
-
         :before {
             white-space: pre;
             content: " ";

--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -3,6 +3,7 @@ import { LinkBlockData, RichTextBlockData } from "@src/blocks.generated";
 import { RawDraftContentState } from "draft-js";
 import * as React from "react";
 import redraft, { Renderers } from "redraft";
+import styled from "styled-components";
 
 import { LinkBlock } from "./LinkBlock";
 
@@ -74,7 +75,7 @@ export const RichTextBlock = withPreview(
 
         return (
             <PreviewSkeleton title={"RichText"} type={"rows"} hasContent={hasDraftContent(draftContent as RawDraftContentState)}>
-                {rendered}
+                <TextWrapper>{rendered}</TextWrapper>
             </PreviewSkeleton>
         );
     },
@@ -84,3 +85,17 @@ export const RichTextBlock = withPreview(
 export function hasDraftContent(draftContent: RawDraftContentState): boolean {
     return !(draftContent.blocks.length == 1 && draftContent.blocks[0].text === "");
 }
+
+const TextWrapper = styled.div`
+    white-space: pre-line;
+
+    //set height on empty p to make it possible to set paragraph spaces in RTE
+    &:empty {
+        margin-bottom: 0;
+
+        :before {
+            white-space: pre;
+            content: " ";
+        }
+    }
+`;

--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -25,32 +25,61 @@ const defaultRenderers: Renderers = {
      */
     blocks: {
         // Paragraph
-        unstyled: (children, { keys }) =>
-            children.map((child, idx) => (
-                <TextWrapper key={keys[idx]}>
-                    <p>{child}</p>
-                </TextWrapper>
-            )),
+        unstyled: (children, { keys }) => children.map((child, idx) => <StyledComponent key={keys[idx]}>{child}</StyledComponent>),
         // Headlines
-        "header-one": (children, { keys }) => children.map((child, idx) => <h1 key={keys[idx]}>{child}</h1>),
-        "header-two": (children, { keys }) => children.map((child, idx) => <h2 key={keys[idx]}>{child}</h2>),
-        "header-three": (children, { keys }) => children.map((child, idx) => <h3 key={keys[idx]}>{child}</h3>),
-        "header-four": (children, { keys }) => children.map((child, idx) => <h4 key={keys[idx]}>{child}</h4>),
-        "header-five": (children, { keys }) => children.map((child, idx) => <h5 key={keys[idx]}>{child}</h5>),
-        "header-six": (children, { keys }) => children.map((child, idx) => <h6 key={keys[idx]}>{child}</h6>),
+        "header-one": (children, { keys }) =>
+            children.map((child, idx) => (
+                <StyledComponent as="h1" key={keys[idx]}>
+                    {child}
+                </StyledComponent>
+            )),
+        "header-two": (children, { keys }) =>
+            children.map((child, idx) => (
+                <StyledComponent as="h2" key={keys[idx]}>
+                    {child}
+                </StyledComponent>
+            )),
+        "header-three": (children, { keys }) =>
+            children.map((child, idx) => (
+                <StyledComponent as="h3" key={keys[idx]}>
+                    {child}
+                </StyledComponent>
+            )),
+        "header-four": (children, { keys }) =>
+            children.map((child, idx) => (
+                <StyledComponent as="h4" key={keys[idx]}>
+                    {child}
+                </StyledComponent>
+            )),
+        "header-five": (children, { keys }) =>
+            children.map((child, idx) => (
+                <StyledComponent as="h5" key={keys[idx]}>
+                    {child}
+                </StyledComponent>
+            )),
+        "header-six": (children, { keys }) =>
+            children.map((child, idx) => (
+                <StyledComponent as="h6" key={keys[idx]}>
+                    {child}
+                </StyledComponent>
+            )),
         // List
         // or depth for nested lists
         "unordered-list-item": (children, { depth, keys }) => (
             <ul key={keys[keys.length - 1]} className={`ul-level-${depth}`}>
                 {children.map((child, index) => (
-                    <li key={keys[index]}>{child}</li>
+                    <StyledComponent as="li" key={keys[index]}>
+                        {child}
+                    </StyledComponent>
                 ))}
             </ul>
         ),
         "ordered-list-item": (children, { depth, keys }) => (
             <ol key={keys.join("|")} className={`ol-level-${depth}`}>
                 {children.map((child, index) => (
-                    <li key={keys[index]}>{child}</li>
+                    <StyledComponent as="li" key={keys[index]}>
+                        {child}
+                    </StyledComponent>
                 ))}
             </ol>
         ),
@@ -91,7 +120,7 @@ export function hasDraftContent(draftContent: RawDraftContentState): boolean {
     return !(draftContent.blocks.length == 1 && draftContent.blocks[0].text === "");
 }
 
-const TextWrapper = styled.div`
+const StyledComponent = styled.p`
     white-space: pre-line;
 
     &:empty {

--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -123,7 +123,7 @@ export function hasDraftContent(draftContent: RawDraftContentState): boolean {
 const Text = styled.p`
     white-space: pre-line;
 
-    // Workaround empty paragraphs used as spacing
+    // Workaround when empty paragraphs are used as "spacing" in content
     &:empty {
         :before {
             white-space: pre;

--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -25,7 +25,12 @@ const defaultRenderers: Renderers = {
      */
     blocks: {
         // Paragraph
-        unstyled: (children, { keys }) => children.map((child, idx) => <p key={keys[idx]}>{child}</p>),
+        unstyled: (children, { keys }) =>
+            children.map((child, idx) => (
+                <TextWrapper key={keys[idx]}>
+                    <p>{child}</p>
+                </TextWrapper>
+            )),
         // Headlines
         "header-one": (children, { keys }) => children.map((child, idx) => <h1 key={keys[idx]}>{child}</h1>),
         "header-two": (children, { keys }) => children.map((child, idx) => <h2 key={keys[idx]}>{child}</h2>),
@@ -75,7 +80,7 @@ export const RichTextBlock = withPreview(
 
         return (
             <PreviewSkeleton title={"RichText"} type={"rows"} hasContent={hasDraftContent(draftContent as RawDraftContentState)}>
-                <TextWrapper>{rendered}</TextWrapper>
+                {rendered}
             </PreviewSkeleton>
         );
     },
@@ -89,7 +94,6 @@ export function hasDraftContent(draftContent: RawDraftContentState): boolean {
 const TextWrapper = styled.div`
     white-space: pre-line;
 
-    //set height on empty p to make it possible to set paragraph spaces in RTE
     &:empty {
         margin-bottom: 0;
 


### PR DESCRIPTION
Line breaks in the RTE block disappeared. To correctly display the text, a TextWrapper was implemented to set paragraph spaces. 

