### PR TITLE
Prevent navigation on validation error

### DIFF
--- a/admin/src/documents/pages/EditPage.tsx
+++ b/admin/src/documents/pages/EditPage.tsx
@@ -17,7 +17,7 @@ import { useContentScope } from "@src/common/ContentScopeProvider";
 import { GQLPageTreeNodeCategory } from "@src/graphql.generated";
 import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { useHistory, useRouteMatch } from "react-router";
+import { useRouteMatch } from "react-router";
 
 import { PageContentBlock } from "./blocks/PageContentBlock";
 import { SeoBlock } from "./blocks/SeoBlock";
@@ -68,13 +68,8 @@ const usePage = createUsePage({
 
 export const EditPage: React.FC<Props> = ({ id, category }) => {
     const intl = useIntl();
-    const history = useHistory();
     const { pageState, rootBlocksApi, hasChanges, loading, dialogs, pageSaveButton, handleSavePage } = usePage({
         pageId: id,
-
-        onValidationFailed: () => {
-            history.push(`${match}/content`);
-        },
     });
 
     const match = useRouteMatch();


### PR DESCRIPTION
The `EditPage` component would push `${match}/content` to the browser history when trying to save an invalid block, resulting in navigating away from where the error occurred. Removing the push resolves the issue.

See https://github.com/vivid-planet/comet/pull/1346