### PR TITLE
Add more precise validation for POSTGRESQL_PWD

### DIFF
--- a/api/src/config/environment-variables.ts
+++ b/api/src/config/environment-variables.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { BlobStorageConfig } from "@comet/cms-api";
 import { Transform, Type } from "class-transformer";
-import { IsBoolean, IsInt, IsOptional, IsString, MinLength, ValidateIf } from "class-validator";
+import { IsBase64, IsBoolean, IsInt, IsOptional, IsString, MinLength, ValidateIf } from "class-validator";
 
 export class EnvironmentVariables {
     @IsString()
@@ -27,7 +27,7 @@ export class EnvironmentVariables {
     @IsString()
     POSTGRESQL_USER?: string;
 
-    @IsString()
+    @IsBase64()
     POSTGRESQL_PWD: string;
 
     @IsString()


### PR DESCRIPTION
We expect the password to be base64 encoded. This is a common source of error when deploying and environment-variables.ts does not indicate that the value should be base64 encoded