### PR TITLE
Add `@next/bundle-analyzer` to site

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -1,6 +1,9 @@
 /* eslint-disable */
 
 // @ts-check
+const withBundleAnalyzer = require("@next/bundle-analyzer")({
+    enabled: process.env.ANALYZE === "true",
+});
 
 const cometConfig = require("./comet-config.json");
 
@@ -112,4 +115,4 @@ const nextConfig = {
     ],
 };
 
-module.exports = nextConfig;
+module.exports = withBundleAnalyzer(nextConfig);

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7,6 +7,7 @@
             "name": "starter-site",
             "dependencies": {
                 "@comet/cms-site": "^5.0.0",
+                "@next/bundle-analyzer": "^12.3.4",
                 "@opentelemetry/api": "^1.4.0",
                 "@opentelemetry/auto-instrumentations-node": "^0.36.1",
                 "@opentelemetry/exporter-trace-otlp-http": "^0.35.1",
@@ -2556,6 +2557,14 @@
                 "@jridgewell/sourcemap-codec": "1.4.14"
             }
         },
+        "node_modules/@next/bundle-analyzer": {
+            "version": "12.3.4",
+            "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-12.3.4.tgz",
+            "integrity": "sha512-eKjgRICzbLTmod0UnJcArFVs5uEAiuZwB6NCf84m+btW7jdylUVoOYf1wi5tA14xk5L9Lho7Prm6/XJ8gxYzfQ==",
+            "dependencies": {
+                "webpack-bundle-analyzer": "4.3.0"
+            }
+        },
         "node_modules/@next/env": {
             "version": "12.3.4",
             "license": "MIT"
@@ -3907,6 +3916,11 @@
             "funding": {
                 "url": "https://opencollective.com/unts"
             }
+        },
+        "node_modules/@polka/url": {
+            "version": "1.0.0-next.23",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
+            "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg=="
         },
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
@@ -5505,7 +5519,6 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
@@ -6377,6 +6390,11 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
         },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
@@ -8079,6 +8097,20 @@
                 "graphql": ">=0.11 <=16"
             }
         },
+        "node_modules/gzip-size": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+            "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+            "dependencies": {
+                "duplexer": "^0.1.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/has": {
             "version": "1.0.3",
             "license": "MIT",
@@ -8099,7 +8131,6 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9513,6 +9544,14 @@
             "version": "1.0.3",
             "license": "MIT"
         },
+        "node_modules/mrmime": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+            "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "license": "MIT"
@@ -10044,6 +10083,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/opener": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+            "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+            "bin": {
+                "opener": "bin/opener-bin.js"
             }
         },
         "node_modules/opentracing": {
@@ -11153,6 +11200,19 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
+        "node_modules/sirv": {
+            "version": "1.0.19",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
+            "integrity": "sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==",
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.20",
+                "mrmime": "^1.0.0",
+                "totalist": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/sitemap": {
             "version": "6.4.0",
             "license": "MIT",
@@ -11534,7 +11594,6 @@
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -11671,6 +11730,14 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
+            }
+        },
+        "node_modules/totalist": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+            "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/tr46": {
@@ -12065,6 +12132,56 @@
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "license": "BSD-2-Clause"
+        },
+        "node_modules/webpack-bundle-analyzer": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.3.0.tgz",
+            "integrity": "sha512-J3TPm54bPARx6QG8z4cKBszahnUglcv70+N+8gUqv2I5KOFHJbzBiLx+pAp606so0X004fxM7hqRu10MLjJifA==",
+            "dependencies": {
+                "acorn": "^8.0.4",
+                "acorn-walk": "^8.0.0",
+                "chalk": "^4.1.0",
+                "commander": "^6.2.0",
+                "gzip-size": "^6.0.0",
+                "lodash": "^4.17.20",
+                "opener": "^1.5.2",
+                "sirv": "^1.0.7",
+                "ws": "^7.3.1"
+            },
+            "bin": {
+                "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+            "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+            "version": "7.5.9",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/whatwg-fetch": {
             "version": "3.6.2",

--- a/site/package.json
+++ b/site/package.json
@@ -26,6 +26,7 @@
     },
     "dependencies": {
         "@comet/cms-site": "^5.0.0",
+        "@next/bundle-analyzer": "^12.3.4",
         "@opentelemetry/api": "^1.4.0",
         "@opentelemetry/auto-instrumentations-node": "^0.36.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.35.1",


### PR DESCRIPTION
We frequently need to inspect the client bundle in the site in our applications. This is done by using the `@next/bundle-analyzer` package. We integrate the package as recommended by [Next](https://github.com/vercel/next.js/tree/canary/packages/next-bundle-analyzer#usage-with-environment-variables). To check the bundle, one can run `ANALYZE=true npm run next-build`.