### PR TITLE
Site: Harmonize preview detection

### DIFF
--- a/.env
+++ b/.env
@@ -55,7 +55,6 @@ SITES_CONFIG='{"main": {"url": "$SITE_URL", "previewUrl": "$SITE_URL/preview/mai
 # site
 SITE_PORT=3000
 SITE_URL=http://${DEV_DOMAIN:-localhost}${WORKAROUND_DOTENV_ISSUE}:${SITE_PORT}
-SITE_IS_PREVIEW=false
 # no gtm in dev mode
 NEXT_PUBLIC_GTM_ID=
 NEXT_PUBLIC_SITE_URL=$SITE_URL

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -12,7 +12,7 @@ const cometConfig = require("./comet-config.json");
  **/
 let i18n = undefined;
 
-if (process.env.SITE_IS_PREVIEW !== "true") {
+if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW !== "true") {
   if (!process.env.NEXT_PUBLIC_SITE_LANGUAGES) {
     throw new Error("Missing environment variable NEXT_PUBLIC_SITE_LANGUAGES");
   }
@@ -36,9 +36,9 @@ if (process.env.SITE_IS_PREVIEW !== "true") {
 const nextConfig = {
     pageExtensions: ["page.ts", "page.tsx"],
     cleanDistDir: process.env.NODE_ENV !== "production", // sitemap and robots.txt are pre-existing
-    basePath: process.env.SITE_IS_PREVIEW === "true" ? "/site" : "",
+    basePath: process.env.NEXT_PUBLIC_SITE_IS_PREVIEW === "true" ? "/site" : "",
     redirects: async () => {
-        if (process.env.SITE_IS_PREVIEW === "true") return [];
+        if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW === "true") return [];
         var redirects = await require("./preBuild/build/preBuild/src/createRedirects").createRedirects();
         return redirects;
     },

--- a/site/src/pages/[[...path]].page.tsx
+++ b/site/src/pages/[[...path]].page.tsx
@@ -123,7 +123,7 @@ const pagesQuery = gql`
 
 export const getStaticPaths: GetStaticPaths = async ({ locales = [] }) => {
     const paths: Array<{ params: { path: string[] }; locale: string }> = [];
-    if (process.env.SITE_IS_PREVIEW !== "true") {
+    if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW !== "true") {
         for (const locale of locales) {
             const data = await createGraphQLClient().request<GQLPagesQuery, GQLPagesQueryVariables>(pagesQuery, {
                 scope: { domain: configuredDomain, language: locale },

--- a/site/src/pages/preview/[domain]/[language]/[[...path]].page.tsx
+++ b/site/src/pages/preview/[domain]/[language]/[[...path]].page.tsx
@@ -15,7 +15,7 @@ export default function AuthenticatedPreviewPage(props: InferGetServerSidePropsT
 }
 
 export const getServerSideProps: GetServerSideProps<PageUniversalProps> = async (context) => {
-    if (process.env.NODE_ENV === "production" && process.env.SITE_IS_PREVIEW !== "true") {
+    if (process.env.NODE_ENV === "production" && process.env.NEXT_PUBLIC_SITE_IS_PREVIEW !== "true") {
         return { notFound: true };
     }
 


### PR DESCRIPTION
Both (env.NEXT_PUBLIC_SITE_IS_PREVIEW and env.SITE_IS_PREVIEW) were used interchangeably, which required both variables to be present (which our helm chart does...).