### PR TITLE
Create DAM entities in application by default

### DIFF
--- a/api/schema.gql
+++ b/api/schema.gql
@@ -234,6 +234,40 @@ type PaginatedProducts {
   totalCount: Int!
 }
 
+type DamFolder {
+  id: ID!
+  name: String!
+  numberOfChildFolders: Int!
+  numberOfFiles: Int!
+  mpath: [ID!]!
+  archived: Boolean!
+  isInboxFromOtherScope: Boolean!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  parent: DamFolder
+  parents: [DamFolder!]!
+}
+
+type DamFile {
+  id: ID!
+  folder: DamFolder
+  name: String!
+  size: Int!
+  mimetype: String!
+  contentHash: String!
+  title: String
+  altText: String
+  archived: Boolean!
+  image: DamFileImage
+  license: DamFileLicense
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  fileUrl: String!
+  duplicates: [DamFile!]!
+  damPath: String!
+  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
+}
+
 type PaginatedPageTreeNodes {
   nodes: [PageTreeNode!]!
   totalCount: Int!
@@ -270,40 +304,6 @@ input DependencyFilter {
 type PaginatedRedirects {
   nodes: [Redirect!]!
   totalCount: Int!
-}
-
-type DamFolder {
-  id: ID!
-  name: String!
-  numberOfChildFolders: Int!
-  numberOfFiles: Int!
-  mpath: [ID!]!
-  archived: Boolean!
-  isInboxFromOtherScope: Boolean!
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  parent: DamFolder
-  parents: [DamFolder!]!
-}
-
-type DamFile {
-  id: ID!
-  folder: DamFolder
-  name: String!
-  size: Int!
-  mimetype: String!
-  contentHash: String!
-  title: String
-  altText: String
-  archived: Boolean!
-  image: DamFileImage
-  license: DamFileLicense
-  createdAt: DateTime!
-  updatedAt: DateTime!
-  fileUrl: String!
-  duplicates: [DamFile!]!
-  damPath: String!
-  dependents(offset: Int! = 0, limit: Int! = 25, filter: DependentFilter, forceRefresh: Boolean! = false): PaginatedDependencies!
 }
 
 type PaginatedDamItems {

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -33,6 +33,8 @@ import { AuthModule } from "./auth/auth.module";
 import { AuthLocalModule } from "./auth/auth-local.module";
 import { Config } from "./config/config";
 import { ConfigModule } from "./config/config.module";
+import { DamFile } from "./dam/entities/dam-file.entity";
+import { DamFolder } from "./dam/entities/dam-folder.entity";
 import { MenusModule } from "./menus/menus.module";
 import { StatusModule } from "./status/status.module";
 
@@ -103,6 +105,8 @@ export class AppModule {
                     backend: config.blob.storage,
                 }),
                 DamModule.register({
+                    File: DamFile,
+                    Folder: DamFolder,
                     damConfig: {
                         filesBaseUrl: `${config.apiUrl}/dam/files`,
                         imagesBaseUrl: `${config.apiUrl}/dam/images`,

--- a/api/src/dam/entities/dam-file.entity.ts
+++ b/api/src/dam/entities/dam-file.entity.ts
@@ -1,0 +1,9 @@
+import { createFileEntity } from "@comet/cms-api";
+
+import { DamFolder } from "./dam-folder.entity";
+
+const DamFile = createFileEntity({ Folder: DamFolder });
+
+type DamFile = typeof DamFile;
+
+export { DamFile };

--- a/api/src/dam/entities/dam-folder.entity.ts
+++ b/api/src/dam/entities/dam-folder.entity.ts
@@ -1,0 +1,7 @@
+import { createFolderEntity } from "@comet/cms-api";
+
+const DamFolder = createFolderEntity();
+
+type DamFolder = typeof DamFolder;
+
+export { DamFolder };


### PR DESCRIPTION
Doing so enables better support for the CRUD Generator and DB migrations.