### PR TITLE
@comet/create-app: Force `git add .` for initial commit

### DIFF
--- a/create-app/src/util/createInitialGitCommit.ts
+++ b/create-app/src/util/createInitialGitCommit.ts
@@ -4,7 +4,7 @@ import kleur from "kleur";
 export function createInitialGitCommit() {
     try {
         execSync("git init");
-        execSync("git add .");
+        execSync("git add . -f");
         const basedOnCommit = execSync('git ls-remote https://github.com/vivid-planet/comet-starter.git | head -1 | sed "s/HEAD//"');
         execSync("git checkout -b setup-project");
         execSync(`git commit -m "Initial commit from Starter" -m "Based on ${basedOnCommit}"`);


### PR DESCRIPTION
When you have a global .gitignore on your machine, some files can be missing from the initial commit, for example `.vscode/`.