### PR TITLE
@comet/create-app: Fix removing create-app/ entries from lint-staged.config.js

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "eslint.workingDirectories": ["admin", "api", "site"]
+    "eslint.workingDirectories": ["admin", "api", "site", "create-app"]
 }

--- a/create-app/src/scripts/remove-site/src/removeSite.ts
+++ b/create-app/src/scripts/remove-site/src/removeSite.ts
@@ -1,26 +1,19 @@
-import * as fs from "fs";
-
 import { cwdIsCometProject } from "../../../util/cwdIsCometProject";
 import { deleteFilesAndFolders } from "../../../util/deleteFilesAndFolders";
+import { removeReferenceInFile } from "../../../util/removeReferenceInFile";
 
 function removeSiteReferences() {
-    removeReference(".vscode/settings.json", /, "site"/g);
-    removeReference(".env", /.*site.*\n/gim);
-    removeReference("install.sh", /.*site.*\n/gim);
-    removeReference(".prettierignore", /.*site.*\n/gim);
-    removeReference("copy-schema-files.js", /.*site.*\n/gim);
-    removeReference("lint-staged.config.js", /.*site.*\n/gim);
-    removeReference("admin/src/environment.ts", /, "SITES_CONFIG"/g);
-    removeReference("./package.json", / browser:site/g);
-    removeReference("./package.json", /.*site.*\n/gim);
-    removeReference("admin/src/config.ts", /.*site.*\n/gim);
-    removeReference("dev-pm.config.js", /{[\n ]*name: "site.*},\n/gis);
-}
-
-function removeReference(filePath: string, regex: RegExp) {
-    const data = fs.readFileSync(filePath, "utf8");
-    const result = data.replace(regex, "");
-    fs.writeFileSync(filePath, result, "utf8");
+    removeReferenceInFile(".vscode/settings.json", /, "site"/g);
+    removeReferenceInFile(".env", /.*site.*\n/gim);
+    removeReferenceInFile("install.sh", /.*site.*\n/gim);
+    removeReferenceInFile(".prettierignore", /.*site.*\n/gim);
+    removeReferenceInFile("copy-schema-files.js", /.*site.*\n/gim);
+    removeReferenceInFile("lint-staged.config.js", /.*site.*\n/gim);
+    removeReferenceInFile("admin/src/environment.ts", /, "SITES_CONFIG"/g);
+    removeReferenceInFile("./package.json", / browser:site/g);
+    removeReferenceInFile("./package.json", /.*site.*\n/gim);
+    removeReferenceInFile("admin/src/config.ts", /.*site.*\n/gim);
+    removeReferenceInFile("dev-pm.config.js", /{[\n ]*name: "site.*},\n/gis);
 }
 
 export function removeSite() {

--- a/create-app/src/util/cleanupWorkingDirectory.ts
+++ b/create-app/src/util/cleanupWorkingDirectory.ts
@@ -1,5 +1,16 @@
+import fs from "fs";
+
 import { deleteFilesAndFolders } from "./deleteFilesAndFolders";
 
 export function cleanupWorkingDirectory(verbose: boolean) {
     deleteFilesAndFolders(["create-app", ".git", ".github", "LICENSE"], verbose);
+
+    const lintStagedConfigFile = fs.readFileSync("lint-staged.config.js", "utf8").toString();
+    fs.writeFileSync(
+        "lint-staged.config.js",
+        lintStagedConfigFile
+            .split("\n")
+            .filter((line) => !line.includes("create-app"))
+            .join("\n"),
+    );
 }

--- a/create-app/src/util/cleanupWorkingDirectory.ts
+++ b/create-app/src/util/cleanupWorkingDirectory.ts
@@ -1,16 +1,8 @@
-import fs from "fs";
-
 import { deleteFilesAndFolders } from "./deleteFilesAndFolders";
+import { removeReferenceInFile } from "./removeReferenceInFile";
 
 export function cleanupWorkingDirectory(verbose: boolean) {
     deleteFilesAndFolders(["create-app", ".git", ".github", "LICENSE"], verbose);
-
-    const lintStagedConfigFile = fs.readFileSync("lint-staged.config.js", "utf8").toString();
-    fs.writeFileSync(
-        "lint-staged.config.js",
-        lintStagedConfigFile
-            .split("\n")
-            .filter((line) => !line.includes("create-app"))
-            .join("\n"),
-    );
+    removeReferenceInFile("lint-staged.config.js", /.*create-app.*\n/gim);
+    removeReferenceInFile(".vscode/settings.json", /, "create-app"/g);
 }

--- a/create-app/src/util/removeReferenceInFile.ts
+++ b/create-app/src/util/removeReferenceInFile.ts
@@ -1,0 +1,7 @@
+import * as fs from "fs";
+
+export function removeReferenceInFile(filePath: string, regex: RegExp) {
+    const data = fs.readFileSync(filePath, "utf8");
+    const result = data.replace(regex, "");
+    fs.writeFileSync(filePath, result, "utf8");
+}

--- a/create-app/src/util/replacePlaceholder.ts
+++ b/create-app/src/util/replacePlaceholder.ts
@@ -19,7 +19,6 @@ export function replacePlaceholder(projectName: string, verbose: boolean): void 
 
             if (placeholder.test(contents)) {
                 if (file.endsWith("intl-update.sh")) fs.writeFileSync(file, contents.replaceAll("lang/starter-lang", `lang/${projectName}-lang`));
-                else if (file.endsWith("lint-staged.config.js")) fs.writeFileSync(file, contents.replaceAll(/"create.*lint:tsc",\n/gs, ""));
                 else fs.writeFileSync(file, contents.replaceAll(placeholder, projectName));
                 changedFiles++;
                 if (verbose) {


### PR DESCRIPTION
Lines were never removed because the placeholder doesn't appear in the config file. Fix by moving code from `replacePlaceholder` to `cleanupWorkingDirectory` (where it actually belongs).