### PR TITLE
Dependabot: Group non-major updates and set interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: "lockfile-only"
+    groups:
+      non-major-versions:
+        update-types:
+          - "minor"
+          - "patch"
     assignees:
       - "johnnyomair"
 
@@ -13,6 +18,11 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: "lockfile-only"
+    groups:
+      non-major-versions:
+        update-types:
+          - "minor"
+          - "patch"
     assignees:
       - "johnnyomair"
 
@@ -21,12 +31,22 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: "lockfile-only"
+    groups:
+      non-major-versions:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/site"
     schedule:
       interval: "daily"
     versioning-strategy: "lockfile-only"
+    groups:
+      non-major-versions:
+        update-types:
+          - "minor"
+          - "patch"
     assignees:
       - "johnnyomair"
 
@@ -35,5 +55,10 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: "lockfile-only"
+    groups:
+      non-major-versions:
+        update-types:
+          - "minor"
+          - "patch"
     assignees:
       - "johnnyomair"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "lockfile-only"
     groups:
       non-major-versions:
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/admin"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "lockfile-only"
     groups:
       non-major-versions:
@@ -29,7 +29,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/api"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "lockfile-only"
     groups:
       non-major-versions:
@@ -40,7 +40,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/site"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "lockfile-only"
     groups:
       non-major-versions:
@@ -53,7 +53,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/create-app"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "lockfile-only"
     groups:
       non-major-versions:


### PR DESCRIPTION
Two suggestions for Dependabot:

## 1) Set interval to weekly 

Makes it less annoying IMO. We could maybe even go to monthly (since we also have a monthly task for the update).

## 2) Group non-major updates

Five PRs will be opened (for root, admin, api, site and create-app) with all non-major updates. Seperate PRs will be created for vulnerable packages and major updates.

see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups 

IMO both suggestions make it less annoying compared to what we currently have:

<img width="737" alt="Bildschirmfoto 2023-12-27 um 09 27 49" src="https://github.com/vivid-planet/comet-starter/assets/13380047/239ff5e3-1c0f-4cc4-8c42-c4043f70a52f">

---

I like the setup my team and me have for a11yphant.com. We use renovate to create a weekly PR with all non-major dependency updates. See, for example, https://github.com/a11yphant/a11yphant/pull/181. I'd like to achieve something similar.
