### PR TITLE
Move favicon from Page.tsx to _document.page.tsx

### DIFF
--- a/site/src/documents/pages/Page.tsx
+++ b/site/src/documents/pages/Page.tsx
@@ -1,7 +1,6 @@
 import { SeoBlock } from "@src/documents/pages/blocks/SeoBlock";
 import { Layout, PropsWithLayout } from "@src/layout/Layout";
 import { gql } from "graphql-request";
-import Head from "next/head";
 import * as React from "react";
 
 import { PageContentBlock } from "./blocks/PageContentBlock";
@@ -27,9 +26,6 @@ export function Page(props: PropsWithLayout<GQLPageQuery>): JSX.Element {
     const document = props.pageContent?.document;
     return (
         <Layout {...props.layout}>
-            <Head>
-                <link rel="icon" href="/favicon.ico" />
-            </Head>
             {document?.__typename === "Page" && (
                 <SeoBlock
                     data={document.seo}

--- a/site/src/pages/_document.page.tsx
+++ b/site/src/pages/_document.page.tsx
@@ -31,7 +31,9 @@ export default class MyDocument extends Document {
     render(): JSX.Element {
         return (
             <Html>
-                <Head />
+                <Head>
+                    <link rel="icon" href="/favicon.ico" />
+                </Head>
                 <body>
                     {process.env.NEXT_PUBLIC_GTM_ID && (
                         <noscript>


### PR DESCRIPTION
Previously, the favicon was added in Page.tsx meaning it was only used for page documents out-of-the-box. This made it easy to forget to add it for static pages and other document types. 

Usually, the favicon is the same for all pages. Thus, I moved it to _document.page.tsx. 