### PR TITLE
Increase JSON request limit to avoid 413 errors

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -50,7 +50,7 @@ async function bootstrap(): Promise<void> {
             contentSecurityPolicy: false, // configure this when API returns HTML
         }),
     );
-    app.use(json({ limit: "1mb" }));
+    app.use(json({ limit: "1mb" })); // increase default limit of 100kb for saving large pages
     app.use(compression());
     app.use(cookieParser());
 

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,3 +1,5 @@
+import { json } from "express";
+
 if (process.env.TRACING_ENABLED) {
     require("./tracing");
 }
@@ -48,6 +50,7 @@ async function bootstrap(): Promise<void> {
             contentSecurityPolicy: false, // configure this when API returns HTML
         }),
     );
+    app.use(json({ limit: "1mb" }));
     app.use(compression());
     app.use(cookieParser());
 


### PR DESCRIPTION
Increase JSON request limit to 1mb

We had to do this in multiple client projects already because we ran into 413 errors when pages got too big:

<img width="658" alt="Bildschirmfoto 2024-01-04 um 12 11 00" src="https://github.com/vivid-planet/comet-starter/assets/13380047/9e3be31d-3c76-4b09-8f39-0094ee24acf1">
