### PR TITLE
Add missing `@SubjectEntity()` decorators to save document mutations

### DIFF
--- a/api/src/documents/links/links.resolver.ts
+++ b/api/src/documents/links/links.resolver.ts
@@ -1,4 +1,4 @@
-import { PageTreeNodeVisibility, PageTreeService, validateNotModified } from "@comet/cms-api";
+import { PageTreeNodeVisibility, PageTreeService, SubjectEntity, validateNotModified } from "@comet/cms-api";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityRepository } from "@mikro-orm/postgresql";
 import { UnauthorizedException } from "@nestjs/common";
@@ -17,6 +17,7 @@ export class LinksResolver {
     }
 
     @Mutation(() => Link)
+    @SubjectEntity(Link, { pageTreeNodeIdArg: "attachedPageTreeNodeId" })
     async saveLink(
         @Args("linkId", { type: () => ID }) linkId: string,
         @Args("input", { type: () => LinkInput }) input: LinkInput,

--- a/api/src/documents/pages/pages.resolver.ts
+++ b/api/src/documents/pages/pages.resolver.ts
@@ -5,6 +5,7 @@ import {
     PageTreeService,
     SortArgs,
     SortDirection,
+    SubjectEntity,
     validateNotModified,
 } from "@comet/cms-api";
 import { QueryOrderMap } from "@mikro-orm/core";
@@ -51,6 +52,7 @@ export class PagesResolver {
     }
 
     @Mutation(() => Page)
+    @SubjectEntity(Page, { pageTreeNodeIdArg: "attachedPageTreeNodeId" })
     async savePage(
         @Args("pageId", { type: () => ID }) pageId: string,
         @Args("input", { type: () => PageInput }) input: PageInput,


### PR DESCRIPTION
Otherwise causes builds across all scopes.