### PR TITLE
Remove `@ValidateNested()` from child block input

### DIFF
--- a/api/src/common/blocks/headline.block.ts
+++ b/api/src/common/blocks/headline.block.ts
@@ -9,7 +9,7 @@ import {
     ExtractBlockInput,
     inputToData,
 } from "@comet/blocks-api";
-import { IsEnum, ValidateNested } from "class-validator";
+import { IsEnum } from "class-validator";
 
 import { RichTextBlock } from "./rich-text.block";
 
@@ -28,7 +28,6 @@ class HeadlineBlockData extends BlockData {
 }
 
 class HeadlineBlockInput extends BlockInput {
-    @ValidateNested()
     @ChildBlockInput(RichTextBlock)
     headline: ExtractBlockInput<typeof RichTextBlock>;
 


### PR DESCRIPTION
Decorator is already included in `@ChildBlockInput()` decorator.