### PR TITLE
Remove direct dependency on `pg`

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -47,7 +47,6 @@
                 "nestjs-console": "^8.0.0",
                 "node-cache": "^5.1.2",
                 "node-fetch": "^2.6.1",
-                "pg": "^8.5.1",
                 "pg-error-constants": "^1.0.0",
                 "reflect-metadata": "^0.1.13",
                 "rimraf": "^3.0.2",

--- a/api/package.json
+++ b/api/package.json
@@ -89,7 +89,6 @@
         "nestjs-console": "^8.0.0",
         "node-cache": "^5.1.2",
         "node-fetch": "^2.6.1",
-        "pg": "^8.5.1",
         "pg-error-constants": "^1.0.0",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",


### PR DESCRIPTION
The [MikroORM docs](https://mikro-orm.io/docs/5.9/installation) recommend to not install the db connector itself, as it's already included in the respective driver package.