### PR TITLE
Fix extracted message's language

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -21,7 +21,7 @@
         "lint:tscPreBuild": "tsc --project tsconfig.preBuild.json",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"npm run generate-block-types\"",
-        "intl:extract": "formatjs extract \"src/**/*.ts*\" --ignore **/*.d.ts --out-file lang-extracted/de.json --format simple",
+        "intl:extract": "formatjs extract \"src/**/*.ts*\" --ignore **/*.d.ts --out-file lang-extracted/en.json --format simple",
         "intl:compile": "formatjs compile-folder --format simple --ast lang/starter-lang/site lang-compiled/"
     },
     "dependencies": {


### PR DESCRIPTION
The language in code is English, so the messages should be extracted into a `en.json` file.