### PR TITLE
Add missing inline styles to `RichTextBlock`

### DIFF
--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -17,6 +17,9 @@ const defaultRenderers: Renderers = {
         // The key passed here is just an index based on rendering order inside a block
         BOLD: (children, { key }) => <strong key={key}>{children}</strong>,
         ITALIC: (children, { key }) => <em key={key}>{children}</em>,
+        SUB: (children, { key }) => <sub key={key}>{children}</sub>,
+        SUP: (children, { key }) => <sup key={key}>{children}</sup>,
+        STRIKETHROUGH: (children, { key }) => <s key={key}>{children}</s>,
     },
     /**
      * Blocks receive children and depth


### PR DESCRIPTION
Styles for Strikethrough, Subscript, and Superscript inline styles were missing in the `defaultRenderers` in the site.

---

<img width="2026" alt="inline styles" src="https://github.com/vivid-planet/comet-starter/assets/48853629/fdd6d42e-36d1-4f8e-b204-18eccd825fcc">


