### PR TITLE
Improve `LinkListBlock` naming

### DIFF
--- a/admin/src/common/blocks/LinkListBlock.tsx
+++ b/admin/src/common/blocks/LinkListBlock.tsx
@@ -1,5 +1,13 @@
 import { createListBlock } from "@comet/blocks-admin";
+import React from "react";
+import { FormattedMessage } from "react-intl";
 
 import { TextLinkBlock } from "./TextLinkBlock";
 
-export const LinkListBlock = createListBlock({ name: "LinkList", block: TextLinkBlock });
+export const LinkListBlock = createListBlock({
+    name: "LinkList",
+    displayName: <FormattedMessage id="linkListBlock.displayName" defaultMessage="Link List" />,
+    block: TextLinkBlock,
+    itemName: <FormattedMessage id="linkListBlock.itemName" defaultMessage="link" />,
+    itemsName: <FormattedMessage id="linkListBlock.itemsName" defaultMessage="links" />,
+});


### PR DESCRIPTION
- Change block name to `Link list`
- Set `itemName` and `itemsName`

---

**Before**

<img width="682" alt="selection before" src="https://github.com/vivid-planet/comet-starter/assets/48853629/f01c0d37-c7dd-4398-a8b3-0335eaf6d6bc">

<img width="682" alt="block before" src="https://github.com/vivid-planet/comet-starter/assets/48853629/d55fb196-a7af-49f7-9bec-5193bd2f2f3e">

**After**

<img width="682" alt="selection after" src="https://github.com/vivid-planet/comet-starter/assets/48853629/c9a9e49c-0138-44df-b7b6-8f16eae2e333">

<img width="682" alt="block after" src="https://github.com/vivid-planet/comet-starter/assets/48853629/4793f9fa-4a6d-4217-b8ff-c7379b8457a5">

