### PR TITLE
Add `ADMIN_URL` to allowed origins in site

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -110,6 +110,10 @@ const nextConfig = {
                         .replace(/\s{2,}/g, " ")
                         .trim(),
                 },
+                {
+                    key: 'Access-Control-Allow-Origin',
+                    value: process.env.ADMIN_URL,
+                 }
             ],
         },
     ],


### PR DESCRIPTION
When making a CORS request to a Next API route from inside the block preview, the request's origin is the Admin URL. This is probably due to the same-origin policy. We need to set the `Access-Control-Allow-Origin` header to allow such requests.