### PR TITLE
Remove `defaultLocale` from `IntlProvider`

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -71,7 +71,7 @@ export function App() {
                         },
                     }}
                 >
-                    <IntlProvider locale="en" defaultLocale="en" messages={getMessages()}>
+                    <IntlProvider locale="en" messages={getMessages()}>
                         <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.domain}>
                             <MuiThemeProvider theme={theme}>
                                 <DndProvider backend={HTML5Backend}>

--- a/site/src/pages/_app.page.tsx
+++ b/site/src/pages/_app.page.tsx
@@ -48,9 +48,7 @@ export default function CustomApp({ Component, pageProps, scope, messages }: Cus
     return (
         // see https://github.com/vercel/next.js/tree/master/examples/with-react-intl
         // for a complete strategy to couple next with react-intl
-        // defaultLocale prevents missing message warning for locale defined in code,
-        // see https://github.com/formatjs/formatjs/issues/251
-        <IntlProvider locale={scope.language} defaultLocale={defaultLanguage} messages={messages}>
+        <IntlProvider locale={scope.language} messages={messages}>
             <Head>
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
             </Head>


### PR DESCRIPTION
react-intl doesn't log an error anymore if a message is missing, so we can remove this workaround.