### PR TITLE
@comet/create-app remove-showcase: Improve and fix regex for content-removal

### DIFF
--- a/create-app/src/scripts/remove-showcase/removeShowcase.ts
+++ b/create-app/src/scripts/remove-showcase/removeShowcase.ts
@@ -11,19 +11,19 @@ async function removeFileContent() {
     }> = [
         {
             file: `./admin/src/Routes.tsx`,
-            replacements: [/\n[ ]*<.*?products.*?>/g],
+            replacements: [/\s*<.*?products.*?>/g],
         },
         {
             file: `./admin/src/common/MasterMenu.tsx`,
-            replacements: [/\n[ ]*<MenuCollapsibleItem.*products`}\n[ ]*\/>\n[ ]*<\/MenuCollapsibleItem>/gs],
+            replacements: [/\s*<MenuCollapsibleItem.*products`}\s*\/>\s*<\/MenuCollapsibleItem>/gs],
         },
         {
             file: `./api/src/app.module.ts`,
-            replacements: [/ProductsModule,\n/gs],
+            replacements: [/\s*ProductsModule,/gs],
         },
         {
             file: `./api/src/db/fixtures/fixtures.console.ts`,
-            replacements: [/, @InjectRepository.*Product.*<Product>/gs, /await Promise.all\(\[generateProducts.*]\);/gs],
+            replacements: [/, @InjectRepository.*Product.*<Product>/gs, /\s*await Promise.all\(\[generateProducts.*]\);/gs],
         },
         {
             file: `./api/src/db/fixtures/fixtures.module.ts`,

--- a/create-app/src/scripts/remove-showcase/removeShowcase.ts
+++ b/create-app/src/scripts/remove-showcase/removeShowcase.ts
@@ -7,15 +7,15 @@ import { deleteFilesAndFolders } from "../../util/deleteFilesAndFolders";
 async function removeFileContent() {
     const contentToRemove: Array<{
         file: string;
-        replacements: RegExp[];
+        replacements: Array<string | RegExp>;
     }> = [
         {
             file: `./admin/src/Routes.tsx`,
-            replacements: [/<.*?products.*?>/gs],
+            replacements: [/\n[ ]*<.*?products.*?>/g],
         },
         {
             file: `./admin/src/common/MasterMenu.tsx`,
-            replacements: [/<MenuItemRouterLink[ \n]*primary={intl.formatMessage\({ id: "comet.menu.products".*products`}[ \n]*\/>/gs],
+            replacements: [/\n[ ]*<MenuCollapsibleItem.*products`}\n[ ]*\/>\n[ ]*<\/MenuCollapsibleItem>/gs],
         },
         {
             file: `./api/src/app.module.ts`,
@@ -23,11 +23,11 @@ async function removeFileContent() {
         },
         {
             file: `./api/src/db/fixtures/fixtures.console.ts`,
-            replacements: [/constructor.*Product.*{}/gs, /await Promise.all\(\[generateProducts.*]\);/gs],
+            replacements: [/, @InjectRepository.*Product.*<Product>/gs, /await Promise.all\(\[generateProducts.*]\);/gs],
         },
         {
             file: `./api/src/db/fixtures/fixtures.module.ts`,
-            replacements: [/imports: \[MikroOrmModule.forFeature\(\[Product]\), ConfigModule, ConsoleModule],/gs],
+            replacements: ["MikroOrmModule.forFeature([Product]), "],
         },
     ];
     const eslint = new ESLint({


### PR DESCRIPTION
The regex is slightly changed in order to:

- Fix an issue, where too much content in "Routes.tsx" is deleted
- Avoid empty lines after the deletion of content
- Don't delete "ConfigModule, ConsoleModule" in "fixture.modules.ts" as it is needed for an import in another module