### PR TITLE
Update security headers

### DIFF
--- a/admin/server/server.js
+++ b/admin/server/server.js
@@ -19,6 +19,12 @@ app.use(
                 "font-src": ["'self'", "https:", "data:"],
             },
         },
+        xXssProtection: false,
+        strictTransportSecurity: {
+            maxAge: 63072000,
+            includeSubDomains: true,
+            preload: true,
+        },
     }),
 );
 

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -72,16 +72,8 @@ const nextConfig = {
                     value: "max-age=63072000; includeSubDomains; preload",
                 },
                 {
-                    key: "Cross-Origin-Embedder-Policy",
-                    value: "require-corp",
-                },
-                {
                     key: "Cross-Origin-Opener-Policy",
                     value: "same-origin",
-                },
-                {
-                    key: "Cross-Origin-Resource-Policy",
-                    value: "same-site"
                 },
                 {
                     key: "Permissions-Policy",

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -94,7 +94,9 @@ const nextConfig = {
                 {
                     key: "Content-Security-Policy",
                     value: `
-                                default-src 'self' https:;
+                                default-src 'self';
+                                form-action 'self'; 
+                                object-src 'none';
                                 img-src 'self' https: data:${process.env.NODE_ENV === "development" ? " http:" : ""};
                                 media-src 'self' https: data:${process.env.NODE_ENV === "development" ? " http:" : ""};
                                 style-src 'self' 'unsafe-inline'; 
@@ -102,6 +104,8 @@ const nextConfig = {
                                 script-src 'self' 'unsafe-inline' https:${process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : ""};
                                 connect-src 'self' https:${process.env.NODE_ENV === "development" ? " http:" : ""};
                                 frame-ancestors ${process.env.ADMIN_URL};
+                                upgrade-insecure-requests; 
+                                block-all-mixed-content;
                             `
                         .replace(/\s{2,}/g, " ")
                         .trim(),

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -84,10 +84,6 @@ const nextConfig = {
                     value: "same-site"
                 },
                 {
-                    key: "X-Frame-Options",
-                    value: "SAMEORIGIN",
-                },
-                {
                     key: "Permissions-Policy",
                     value: "",
                 },

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -76,6 +76,10 @@ const nextConfig = {
                     value: "require-corp",
                 },
                 {
+                    key: "Cross-Origin-Opener-Policy",
+                    value: "same-origin",
+                },
+                {
                     key: "X-XSS-Protection",
                     value: "1; mode=block",
                 },

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -84,10 +84,6 @@ const nextConfig = {
                     value: "same-site"
                 },
                 {
-                    key: "X-XSS-Protection",
-                    value: "1; mode=block",
-                },
-                {
                     key: "X-Frame-Options",
                     value: "SAMEORIGIN",
                 },

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -68,10 +68,6 @@ const nextConfig = {
             source: "/:path*",
             headers: [
                 {
-                    key: "X-DNS-Prefetch-Control",
-                    value: "on",
-                },
-                {
                     key: "Strict-Transport-Security",
                     value: "max-age=63072000; includeSubDomains; preload",
                 },

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -80,6 +80,10 @@ const nextConfig = {
                     value: "same-origin",
                 },
                 {
+                    key: "Cross-Origin-Resource-Policy",
+                    value: "same-site"
+                },
+                {
                     key: "X-XSS-Protection",
                     value: "1; mode=block",
                 },

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -72,6 +72,10 @@ const nextConfig = {
                     value: "max-age=63072000; includeSubDomains; preload",
                 },
                 {
+                    key: "Cross-Origin-Embedder-Policy",
+                    value: "require-corp",
+                },
+                {
                     key: "X-XSS-Protection",
                     value: "1; mode=block",
                 },


### PR DESCRIPTION
The Security Headers are updated because of some recent changes in the MDN best practices. In addition, some deprecated headers like x-xss-protection are removed and new headers like the COOP are introduced.

The new header configuration is based on the [MDN best practices](https://developer.mozilla.org/en-US/docs/Web/Security) and [OWASP-Recommended headers](https://owasp.org/www-project-secure-headers/).