### PR TITLE
@comet/create-app remove-site: Don't remove sites config

### DIFF
--- a/create-app/src/scripts/remove-site/removeSite.ts
+++ b/create-app/src/scripts/remove-site/removeSite.ts
@@ -3,15 +3,13 @@ import { removeReferenceInFile } from "../../util/removeReferenceInFile";
 
 function removeSiteReferences() {
     removeReferenceInFile(".vscode/settings.json", /, "site"/g);
-    removeReferenceInFile(".env", /.*site.*\n/gim);
+    removeReferenceInFile(".env", /# site.*NEXT_PUBLIC_SITE_IS_PREVIEW=false\n\n/gms);
     removeReferenceInFile("install.sh", /.*site.*\n/gim);
     removeReferenceInFile(".prettierignore", /.*site.*\n/gim);
     removeReferenceInFile("copy-schema-files.js", /.*site.*\n/gim);
     removeReferenceInFile("lint-staged.config.js", /.*site.*\n/gim);
-    removeReferenceInFile("admin/src/environment.ts", /, "SITES_CONFIG"/g);
     removeReferenceInFile("./package.json", / browser:site/g);
     removeReferenceInFile("./package.json", /.*site.*\n/gim);
-    removeReferenceInFile("admin/src/config.ts", /.*site.*\n/gim);
     removeReferenceInFile("dev-pm.config.js", /{[\n ]*name: "site.*},\n/gis);
 }
 


### PR DESCRIPTION
Without the sites config, it is not possible to show the page tree. To avoid this, the sites config references are no longer removed with the remove-site command.  