### PR TITLE
Fix product creation

### DIFF
--- a/api/src/auth/static-users.ts
+++ b/api/src/auth/static-users.ts
@@ -2,7 +2,7 @@ import { User } from "@comet/cms-api";
 
 export const staticUsers: User[] = [
     {
-        id: "1",
+        id: "a19a100d-3bce-4b29-ad47-e6119d15923e",
         name: "Admin",
         email: "demo@comet-dxp.com",
         language: "en",

--- a/api/src/auth/user.service.ts
+++ b/api/src/auth/user.service.ts
@@ -6,9 +6,13 @@ import { staticUsers } from "./static-users";
 @Injectable()
 export class UserService implements UserPermissionsUserServiceInterface {
     getUser(id: string): User {
-        const index = parseInt(id) - 1;
-        if (staticUsers[index]) return staticUsers[index];
-        throw new Error("User not found");
+        const user = staticUsers.find((user) => user.id === id);
+
+        if (!user) {
+            throw new Error("User not found");
+        }
+
+        return user;
     }
     findUsers(args: FindUsersArgs): Users {
         const search = args.search?.toLowerCase();

--- a/api/src/db/fixtures/generators/product.fixture.ts
+++ b/api/src/db/fixtures/generators/product.fixture.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { EntityRepository } from "@mikro-orm/postgresql";
+import { staticUsers } from "@src/auth/static-users";
 import { Product } from "@src/products/entities/product.entity";
 import { mapLimit } from "async";
 import { SingleBar } from "cli-progress";
@@ -12,7 +13,7 @@ interface GenerateProducts {
 
 export const generateProducts = async ({ repository, bar, total }: GenerateProducts): Promise<Product[]> => {
     const generateRandomProduct = async (): Promise<Product> => {
-        const product = repository.create({ name: faker.lorem.word(), description: faker.lorem.words(), creatorId: faker.string.uuid() });
+        const product = repository.create({ name: faker.lorem.word(), description: faker.lorem.words(), creatorId: staticUsers[0].id });
         repository.persist(product);
 
         bar.increment(1, {


### PR DESCRIPTION
The `creatorId` column of the `Product` entity expects a UUID value. We therefore change the ID of the static user used in local development to a UUID.