### PR TITLE
Remove own prettier config from admin and site

### DIFF
--- a/admin/.prettierrc.json
+++ b/admin/.prettierrc.json
@@ -1,6 +1,0 @@
-{
-    "printWidth": 150,
-    "tabWidth": 4,
-    "trailingComma": "all",
-    "semi": true
-}

--- a/site/.prettierrc.json
+++ b/site/.prettierrc.json
@@ -1,6 +1,0 @@
-{
-    "printWidth": 150,
-    "tabWidth": 4,
-    "trailingComma": "all",
-    "semi": true
-}


### PR DESCRIPTION
admin and site had their own prettier configurations. This caused an override of our global prettier config resulting in different formatting of yml files in admin and site compared to api.

---

Global Config:

https://github.com/vivid-planet/comet-starter/blob/e1f177493ca9abae79fae45bde2706483c740458/.prettierrc#L1-L14