### PR TITLE
Allow Prettier in IDE for microservices

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,9 +9,3 @@
 
 # Go Templates can not be formatted with prettier (https://github.com/prettier/prettier/issues/6517)
 chart/*/templates/*
-
-# Microservices are checked by each microservice on its own
-admin/
-api/
-site/
-create-app/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "dev": "dotenv -c secrets -- dev-pm start",
         "copy-schema-files": "node copy-schema-files.js",
         "lint": "run-p lint:*",
-        "lint:root": "npx prettier --check './*.{js,json,md,yml,yaml}'",
+        "lint:root": "npx prettier --check './!(admin|api|site|create-app)/**/*.{js,json,md,yml,yaml}'",
         "lint:api": "npm --prefix api run lint",
         "lint:admin": "npm --prefix admin run lint",
         "lint:site": "npm --prefix site run lint",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
         "dev": "dotenv -c secrets -- dev-pm start",
         "copy-schema-files": "node copy-schema-files.js",
         "lint": "run-p lint:*",
-        "lint:root": "npx prettier --check './**/*.{js,json,md,yml,yaml}'",
+        "lint:root": "npx prettier --check './*.{js,json,md,yml,yaml}'",
         "lint:api": "npm --prefix api run lint",
         "lint:admin": "npm --prefix admin run lint",
         "lint:site": "npm --prefix site run lint",


### PR DESCRIPTION
https://github.com/vivid-planet/comet-starter/pull/95#issue-2064259483

Fixes the "bad IDE support" by allowing allowing prettier in IDE for api/admin/site/create-app but executing the cli-check only for root-files.