### PR TITLE
Create rewrites to avoid redirect loop

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -42,7 +42,7 @@ const nextConfig = {
     },
     redirects: async () => {
         if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW === "true") return [];
-        var { redirects } = await require("./preBuild/build/preBuild/src/createRedirects").createRedirects();
+        var redirects = await require("./preBuild/build/preBuild/src/createRedirects").createRedirects();
         return redirects;
     },
     images: {

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -37,7 +37,7 @@ const nextConfig = {
     basePath: process.env.NEXT_PUBLIC_SITE_IS_PREVIEW === "true" ? "/site" : "",
     rewrites: async () => {
         if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW === "true") return [];
-        var { rewrites } = await require("./preBuild/build/preBuild/src/createRedirects").createRedirects();
+        var rewrites = await require("./preBuild/build/preBuild/src/createRewrites").createRewrites();
         return rewrites;
     },
     redirects: async () => {

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -35,9 +35,14 @@ const nextConfig = {
     pageExtensions: ["page.ts", "page.tsx"],
     cleanDistDir: process.env.NODE_ENV !== "production", // sitemap and robots.txt are pre-existing
     basePath: process.env.NEXT_PUBLIC_SITE_IS_PREVIEW === "true" ? "/site" : "",
+    rewrites: async () => {
+        if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW === "true") return [];
+        var { rewrites } = await require("./preBuild/build/preBuild/src/createRedirects").createRedirects();
+        return rewrites;
+    },
     redirects: async () => {
         if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW === "true") return [];
-        var redirects = await require("./preBuild/build/preBuild/src/createRedirects").createRedirects();
+        var { redirects } = await require("./preBuild/build/preBuild/src/createRedirects").createRedirects();
         return redirects;
     },
     images: {

--- a/site/preBuild/src/createRedirects.ts
+++ b/site/preBuild/src/createRedirects.ts
@@ -89,7 +89,7 @@ const createApiRedirects = async (): Promise<Redirect[]> => {
             continue;
         }
 
-        if (source && destination && source.toLowerCase() !== destination.toLowerCase()) {
+        if (source && destination) {
             redirects.push({ source, destination, permanent: true });
         }
     }

--- a/site/preBuild/src/createRedirects.ts
+++ b/site/preBuild/src/createRedirects.ts
@@ -24,7 +24,7 @@ const redirectsQuery = gql`
     }
 `;
 
-async function* getRedirects() {
+export async function* getRedirects() {
     let offset = 0;
     const limit = 100;
 
@@ -87,21 +87,13 @@ const createApiRedirects = async (): Promise<{ redirects: Redirect[]; rewrites: 
             }
         }
 
-        if (source === destination) {
+        if (source?.toLowerCase() === destination?.toLowerCase()) {
             console.warn(`Skipping redirect loop ${source} -> ${destination}`);
             continue;
         }
 
-        if (source && destination) {
-            if (source.toLowerCase() === destination.toLowerCase()) {
-                const newSource = source
-                    .split("")
-                    .map((char) => (char.toLowerCase() === char.toUpperCase() ? char : `(${char.toLowerCase()}|${char.toUpperCase()})`))
-                    .join("");
-                rewrites.push({ source: newSource, destination });
-            } else {
-                redirects.push({ source, destination, permanent: true });
-            }
+        if (source && destination && source.toLowerCase() !== destination.toLowerCase()) {
+            redirects.push({ source, destination, permanent: true });
         }
     }
 

--- a/site/preBuild/src/createRedirects.ts
+++ b/site/preBuild/src/createRedirects.ts
@@ -1,14 +1,12 @@
 import { gql } from "graphql-request";
-import { Redirect, Rewrite } from "next/dist/lib/load-custom-routes";
+import { Redirect } from "next/dist/lib/load-custom-routes";
 
 import { ExternalLinkBlockData, InternalLinkBlockData, RedirectsLinkBlockData } from "../../src/blocks.generated";
 import { createGraphQLClient } from "../../src/util/createGraphQLClient";
 import { GQLRedirectsQuery, GQLRedirectsQueryVariables } from "./createRedirects.generated";
 
 const createRedirects = async () => {
-    const { rewrites, redirects } = await createApiRedirects();
-
-    return { rewrites, redirects: [...redirects, ...(await createInternalRedirects())] };
+    return [...(await createApiRedirects()), ...(await createInternalRedirects())];
 };
 
 const redirectsQuery = gql`
@@ -55,15 +53,14 @@ const createInternalRedirects = async (): Promise<Redirect[]> => {
         },
     ];
 };
-const createApiRedirects = async (): Promise<{ redirects: Redirect[]; rewrites: Rewrite[] }> => {
+const createApiRedirects = async (): Promise<Redirect[]> => {
     const apiUrl = process.env.API_URL_INTERNAL;
     if (!apiUrl) {
         console.error("No Environment Variable API_URL_INTERNAL available. Can not perform redirect config");
-        return { redirects: [], rewrites: [] };
+        return [];
     }
 
     const redirects: Redirect[] = [];
-    const rewrites: Rewrite[] = [];
 
     for await (const redirect of getRedirects()) {
         let source: string | undefined;
@@ -97,7 +94,7 @@ const createApiRedirects = async (): Promise<{ redirects: Redirect[]; rewrites: 
         }
     }
 
-    return { redirects, rewrites };
+    return redirects;
 };
 
 export { createRedirects };

--- a/site/preBuild/src/createRewrites.ts
+++ b/site/preBuild/src/createRewrites.ts
@@ -1,6 +1,5 @@
 import { Rewrite } from "next/dist/lib/load-custom-routes";
 
-import { ExternalLinkBlockData, InternalLinkBlockData, RedirectsLinkBlockData } from "../../src/blocks.generated";
 import { getRedirects } from "./createRedirects";
 
 const createRewrites = async () => {
@@ -13,26 +12,7 @@ const createRewrites = async () => {
     const rewrites: Rewrite[] = [];
 
     for await (const redirect of getRedirects()) {
-        let source: string | undefined;
-        let destination: string | undefined;
-
-        if (redirect.sourceType === "path") {
-            source = redirect.source;
-        }
-
-        const target = redirect.target as RedirectsLinkBlockData;
-
-        if (target.block !== undefined) {
-            switch (target.block.type) {
-                case "internal":
-                    destination = (target.block.props as InternalLinkBlockData).targetPage?.path;
-                    break;
-
-                case "external":
-                    destination = (target.block.props as ExternalLinkBlockData).targetUrl;
-                    break;
-            }
-        }
+        const { source, destination } = redirect;
 
         if (source && destination && source.toLowerCase() === destination.toLowerCase()) {
             const firstChar = source.charAt(1);

--- a/site/preBuild/src/createRewrites.ts
+++ b/site/preBuild/src/createRewrites.ts
@@ -15,11 +15,7 @@ const createRewrites = async () => {
         const { source, destination } = redirect;
 
         if (source && destination && source.toLowerCase() === destination.toLowerCase()) {
-            const firstChar = source.charAt(1);
-
-            const pattern = new RegExp(`(${firstChar.toLowerCase()}|${firstChar.toUpperCase()})`, "g");
-
-            rewrites.push({ source: source.replace(pattern, "($1)"), destination });
+            rewrites.push({ source, destination });
         }
     }
 

--- a/site/preBuild/src/createRewrites.ts
+++ b/site/preBuild/src/createRewrites.ts
@@ -14,8 +14,8 @@ const createRewrites = async () => {
     for await (const redirect of getRedirects()) {
         const { source, destination } = redirect;
 
-        /* A rewrite is created for each redirect where source and destination differ only by casing (otherwise this causes a redirection loop).
-        E.g. a rewrite is created for the redirect /Example -> /example*/
+        // A rewrite is created for each redirect where the source and destination differ only by casing (otherwise, this causes a redirection loop).
+        // For instance, a rewrite is created for the redirect /Example -> /example.
         if (source && destination && source.toLowerCase() === destination.toLowerCase()) {
             rewrites.push({ source, destination });
         }

--- a/site/preBuild/src/createRewrites.ts
+++ b/site/preBuild/src/createRewrites.ts
@@ -1,0 +1,49 @@
+import { Rewrite } from "next/dist/lib/load-custom-routes";
+
+import { ExternalLinkBlockData, InternalLinkBlockData, RedirectsLinkBlockData } from "../../src/blocks.generated";
+import { getRedirects } from "./createRedirects";
+
+const createRewrites = async () => {
+    const apiUrl = process.env.API_URL_INTERNAL;
+    if (!apiUrl) {
+        console.error("No Environment Variable API_URL_INTERNAL available. Can not perform redirect config");
+        return { redirects: [], rewrites: [] };
+    }
+
+    const rewrites: Rewrite[] = [];
+
+    for await (const redirect of getRedirects()) {
+        let source: string | undefined;
+        let destination: string | undefined;
+
+        if (redirect.sourceType === "path") {
+            source = redirect.source;
+        }
+
+        const target = redirect.target as RedirectsLinkBlockData;
+
+        if (target.block !== undefined) {
+            switch (target.block.type) {
+                case "internal":
+                    destination = (target.block.props as InternalLinkBlockData).targetPage?.path;
+                    break;
+
+                case "external":
+                    destination = (target.block.props as ExternalLinkBlockData).targetUrl;
+                    break;
+            }
+        }
+
+        if (source && destination && source.toLowerCase() === destination.toLowerCase()) {
+            const firstChar = source.charAt(1);
+
+            const pattern = new RegExp(`(${firstChar.toLowerCase()}|${firstChar.toUpperCase()})`, "g");
+
+            rewrites.push({ source: source.replace(pattern, "($1)"), destination });
+        }
+    }
+
+    return rewrites;
+};
+
+export { createRewrites };

--- a/site/preBuild/src/createRewrites.ts
+++ b/site/preBuild/src/createRewrites.ts
@@ -14,6 +14,8 @@ const createRewrites = async () => {
     for await (const redirect of getRedirects()) {
         const { source, destination } = redirect;
 
+        /* A rewrite is created for each redirect where source and destination differ only by casing (otherwise this causes a redirection loop).
+        E.g. a rewrite is created for the redirect /Example -> /example*/
         if (source && destination && source.toLowerCase() === destination.toLowerCase()) {
             rewrites.push({ source, destination });
         }


### PR DESCRIPTION
Creates rewrites for redirect loop, as case sensitivity in Next.js is inconsistent (see also https://github.com/vercel/next.js/issues/21498#issuecomment-848315717).

Background:

Sometimes you want a redirect from an uppercase to a lowercase URL (e.g. /Example to /example) for SEO purposes. This can be created in our admin without problems. The casing is saved correctly in the DB and transferred to Next.

The problem is that this creates a redirect loop in the site. The reason is that the case sensitivity of Next.js is inconsistent. The delivery of pages is case sensitive. The redirects are case insensitive:

Without redirect:

http://localhost:3000/example -> page is delivered
http://localhost:3000/Example -> 404

With redirect:

http://localhost:3000/example -> Redirect to /example -> Loop
http://localhost:3000/Example -> Redirect to /example -> Loop

Also described here: https://github.com/vercel/next.js/issues/21498