### PR TITLE
Always set alternate link of current language

### DIFF
--- a/site/src/documents/pages/blocks/SeoBlock.tsx
+++ b/site/src/documents/pages/blocks/SeoBlock.tsx
@@ -1,5 +1,6 @@
 import { generateImageUrl, PropsWithData } from "@comet/cms-site";
 import { SeoBlockData } from "@src/blocks.generated";
+import { useContentScope } from "@src/common/contentScope/ContentScope";
 import Head from "next/head";
 import * as React from "react";
 
@@ -12,6 +13,7 @@ export const SeoBlock: React.FunctionComponent<SeoBlockProps> = ({
     title,
     canonicalUrl,
 }) => {
+    const { language } = useContentScope();
     const usedHtmlTitle = htmlTitle && htmlTitle != "" ? htmlTitle : title;
     return (
         <>
@@ -21,6 +23,7 @@ export const SeoBlock: React.FunctionComponent<SeoBlockProps> = ({
                 {/* Meta*/}
                 {metaDescription && <meta name="description" content={metaDescription} />}
                 <link rel="canonical" href={canonicalUrl} />
+                <link rel="alternate" hrefLang={language} href={canonicalUrl} />
                 {alternativeLinks.map((link) => (
                     <link key={link.code} rel="alternate" hrefLang={link.code} href={link.url} />
                 ))}


### PR DESCRIPTION
**Description:**

we were recently advised by a SEO agency to always set the language of the current page as an alternate link. 

I looked it up myself and it seems to make sense:

https://developers.google.com/search/blog/2014/05/creating-right-homepage-for-your

<img width="916" alt="Screenshot 2024-03-05 at 21 24 05" src="https://github.com/vivid-planet/comet-starter/assets/44967610/32876b9a-e826-40e1-b760-7922de1cd7a8">


**Result:**
<img width="483" alt="Screenshot 2024-03-05 at 21 19 18" src="https://github.com/vivid-planet/comet-starter/assets/44967610/8f5ec865-5e30-4b75-a751-2fa608f8a46d">
