### PR TITLE
@comet/create-app: Support Comet v6

### DIFF
--- a/admin/src/common/masterMenuData.tsx
+++ b/admin/src/common/masterMenuData.tsx
@@ -70,6 +70,8 @@ export const masterMenuData: MasterMenuData = [
         },
         requiredPermission: "pageTree",
     },
+    // This line is needed for @comet/create-app (Do not remove this line)
+    // https://github.com/vivid-planet/comet-starter/pull/194#discussion_r1519813689
     {
         primary: <FormattedMessage id="menu.structuredContent" defaultMessage="Structured Content" />,
         icon: <Data />,

--- a/create-app/src/scripts/remove-showcase/removeShowcase.ts
+++ b/create-app/src/scripts/remove-showcase/removeShowcase.ts
@@ -11,7 +11,7 @@ async function removeFileContent() {
     }> = [
         {
             file: `./admin/src/common/masterMenuData.tsx`,
-            replacements: [/.{217}\.products.*?,\s{5}},\n/gs, /.*Products.*/gm],
+            replacements: [/\s*\/\/ This.*\.products.*?,\s{5}},/gs, /.*Products.*/gm],
         },
         {
             file: `api/src/auth/permission.interface.ts`,

--- a/create-app/src/scripts/remove-showcase/removeShowcase.ts
+++ b/create-app/src/scripts/remove-showcase/removeShowcase.ts
@@ -10,16 +10,16 @@ async function removeFileContent() {
         replacements: Array<string | RegExp>;
     }> = [
         {
-            file: `./admin/src/Routes.tsx`,
-            replacements: [/\s*<.*?products.*?>/g],
+            file: `./admin/src/common/masterMenuData.tsx`,
+            replacements: [/.{217}\.products.*?,\s{5}},\n/gs, /.*Products.*/gm],
         },
         {
-            file: `./admin/src/common/MasterMenu.tsx`,
-            replacements: [/\s*<MenuCollapsibleItem.*products`}\s*\/>\s*<\/MenuCollapsibleItem>/gs],
+            file: `api/src/auth/permission.interface.ts`,
+            replacements: [/\n.*products.*?}\n/gs],
         },
         {
             file: `./api/src/app.module.ts`,
-            replacements: [/\s*ProductsModule,/gs],
+            replacements: [/\s*ProductsModule,/gs, '"products"'],
         },
         {
             file: `./api/src/db/fixtures/fixtures.console.ts`,


### PR DESCRIPTION
This PR adds following changes:
- Support for @comet/create-app in Comet v6