### PR TITLE
Configure admin to wait for API before starting

### DIFF
--- a/dev-pm.config.js
+++ b/dev-pm.config.js
@@ -9,6 +9,7 @@ module.exports = {
             name: "admin",
             script: "npm run --prefix admin start",
             group: "admin",
+            waitOn: ["tcp:$API_PORT"],
         },
         {
             name: "admin-codegen",


### PR DESCRIPTION
`waitOn` wasn't configured for admin. Previously, this didn't strike because the admin startup was slower than API anyway. But with vite, the admin is faster, leading to a "fetch error" initially.