### PR TITLE
Create block index view before starting API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,7 @@
         "mikro-orm:migration:generate": "mikro-orm migration:create",
         "start": "npm run prebuild && dotenv -c secrets -- nest start",
         "start:debug": "npm run prebuild && dotenv -c secrets -- nest start --debug --watch --preserveWatchOutput",
-        "start:dev": "npm run prebuild && dotenv -c secrets -- nest start --watch --preserveWatchOutput",
+        "start:dev": "npm run prebuild && npm run db:migrate && npm run console createBlockIndexViews && dotenv -c secrets -- nest start --watch --preserveWatchOutput",
         "start:prod": "node dist/main",
         "test": "jest --passWithNoTests",
         "test:ci": "npm run test -- --ci --reporters=default --reporters=jest-junit",

--- a/dev-pm.config.js
+++ b/dev-pm.config.js
@@ -24,7 +24,7 @@ module.exports = {
         },
         {
             name: "api",
-            script: "npm --prefix api run db:migrate && npm --prefix api run start:dev",
+            script: "npm --prefix api run start:dev",
             group: "api",
             waitOn: ["tcp:$POSTGRESQL_PORT", "tcp:$IMGPROXY_PORT"],
         },


### PR DESCRIPTION
Otherwise, you get an error message when visiting the dependents tab. The reason is that it tries to refresh a view that doesn't exist

<img width="1047" alt="Bildschirmfoto 2024-03-21 um 00 02 29" src="https://github.com/vivid-planet/comet-starter/assets/13380047/e3a43925-7a4b-4e3e-8564-393fe2a68961">
