### PR TITLE
Use Vivid Planet Bot token for main-into-next-PR creation

### DIFF
--- a/.github/workflows/main-into-next-pr.yml
+++ b/.github/workflows/main-into-next-pr.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
           title: ${{ env.PR_TITLE }}
           body: ${{ env.PR_BODY }}
           base: next


### PR DESCRIPTION
Otherwise the Lint workflow is not triggered. See [docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) for more information.