### PR TITLE
Access Admin config via dependency injection

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -54,45 +54,45 @@ const apiClient = createHttpClient(config.apiUrl);
 
 export function App() {
     return (
-        <ApolloProvider client={apolloClient}>
-            <CurrentUserProvider>
-                <BuildInformationProvider value={{ date: config.buildDate, number: config.buildNumber, commitHash: config.commitSha }}>
-                    <SitesConfigProvider
-                        value={{
-                            configs: config.sitesConfig,
-                            resolveSiteConfigForScope: (configs: Record<string, SiteConfig>, scope: ContentScope) => {
-                                const siteConfig = configs[scope.domain];
-                                return {
-                                    ...siteConfig,
-                                    previewUrl: `${siteConfig.previewUrl}/${scope.language}`,
-                                };
-                            },
-                        }}
-                    >
-                        <DependenciesConfigProvider
-                            entityDependencyMap={{
-                                Page,
-                                Link,
-                                DamFile: createDamFileDependency(),
+        <ConfigProvider config={config}>
+            <ApolloProvider client={apolloClient}>
+                <CurrentUserProvider>
+                    <BuildInformationProvider value={{ date: config.buildDate, number: config.buildNumber, commitHash: config.commitSha }}>
+                        <SitesConfigProvider
+                            value={{
+                                configs: config.sitesConfig,
+                                resolveSiteConfigForScope: (configs: Record<string, SiteConfig>, scope: ContentScope) => {
+                                    const siteConfig = configs[scope.domain];
+                                    return {
+                                        ...siteConfig,
+                                        previewUrl: `${siteConfig.previewUrl}/${scope.language}`,
+                                    };
+                                },
                             }}
                         >
-                            <IntlProvider locale="en" messages={getMessages()}>
-                                <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.domain}>
-                                    <MuiThemeProvider theme={theme}>
-                                        <DndProvider backend={HTML5Backend}>
-                                            <SnackbarProvider>
-                                                <CmsBlockContextProvider
-                                                    damConfig={{
-                                                        apiUrl: config.apiUrl,
-                                                        apiClient,
-                                                        maxFileSize: config.dam.uploadsMaxFileSize,
-                                                        maxSrcResolution: config.imgproxy.maxSrcResolution,
-                                                        allowedImageAspectRatios: config.dam.allowedImageAspectRatios,
-                                                    }}
-                                                    pageTreeCategories={pageTreeCategories}
-                                                    pageTreeDocumentTypes={pageTreeDocumentTypes}
-                                                >
-                                                    <ConfigProvider config={config}>
+                            <DependenciesConfigProvider
+                                entityDependencyMap={{
+                                    Page,
+                                    Link,
+                                    DamFile: createDamFileDependency(),
+                                }}
+                            >
+                                <IntlProvider locale="en" messages={getMessages()}>
+                                    <LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.domain}>
+                                        <MuiThemeProvider theme={theme}>
+                                            <DndProvider backend={HTML5Backend}>
+                                                <SnackbarProvider>
+                                                    <CmsBlockContextProvider
+                                                        damConfig={{
+                                                            apiUrl: config.apiUrl,
+                                                            apiClient,
+                                                            maxFileSize: config.dam.uploadsMaxFileSize,
+                                                            maxSrcResolution: config.imgproxy.maxSrcResolution,
+                                                            allowedImageAspectRatios: config.dam.allowedImageAspectRatios,
+                                                        }}
+                                                        pageTreeCategories={pageTreeCategories}
+                                                        pageTreeDocumentTypes={pageTreeDocumentTypes}
+                                                    >
                                                         <RouterBrowserRouter>
                                                             <GlobalStyle />
                                                             <ContentScopeProvider>
@@ -117,17 +117,17 @@ export function App() {
                                                             </ContentScopeProvider>
                                                             <ErrorDialogHandler />
                                                         </RouterBrowserRouter>
-                                                    </ConfigProvider>
-                                                </CmsBlockContextProvider>
-                                            </SnackbarProvider>
-                                        </DndProvider>
-                                    </MuiThemeProvider>
-                                </LocaleProvider>
-                            </IntlProvider>
-                        </DependenciesConfigProvider>
-                    </SitesConfigProvider>
-                </BuildInformationProvider>
-            </CurrentUserProvider>
-        </ApolloProvider>
+                                                    </CmsBlockContextProvider>
+                                                </SnackbarProvider>
+                                            </DndProvider>
+                                        </MuiThemeProvider>
+                                    </LocaleProvider>
+                                </IntlProvider>
+                            </DependenciesConfigProvider>
+                        </SitesConfigProvider>
+                    </BuildInformationProvider>
+                </CurrentUserProvider>
+            </ApolloProvider>
+        </ConfigProvider>
     );
 }

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -35,7 +35,7 @@ import { createApolloClient } from "./common/apollo/createApolloClient";
 import { ContentScopeProvider } from "./common/ContentScopeProvider";
 import { MasterHeader } from "./common/MasterHeader";
 import { masterMenuData, pageTreeCategories, pageTreeDocumentTypes } from "./common/masterMenuData";
-import { createConfig } from "./config";
+import { ConfigProvider, createConfig } from "./config";
 import { Link } from "./documents/links/Link";
 import { Page } from "./documents/pages/Page";
 
@@ -92,30 +92,32 @@ export function App() {
                                                     pageTreeCategories={pageTreeCategories}
                                                     pageTreeDocumentTypes={pageTreeDocumentTypes}
                                                 >
-                                                    <RouterBrowserRouter>
-                                                        <GlobalStyle />
-                                                        <ContentScopeProvider>
-                                                            {({ match }) => (
-                                                                <Switch>
-                                                                    <Route
-                                                                        path={`${match.path}/preview`}
-                                                                        render={(props) => <SitePreview {...props} />}
-                                                                    />
-                                                                    <Route
-                                                                        render={() => (
-                                                                            <MasterLayout
-                                                                                headerComponent={MasterHeader}
-                                                                                menuComponent={() => <MasterMenu menu={masterMenuData} />}
-                                                                            >
-                                                                                <MasterMenuRoutes menu={masterMenuData} />
-                                                                            </MasterLayout>
-                                                                        )}
-                                                                    />
-                                                                </Switch>
-                                                            )}
-                                                        </ContentScopeProvider>
-                                                        <ErrorDialogHandler />
-                                                    </RouterBrowserRouter>
+                                                    <ConfigProvider config={config}>
+                                                        <RouterBrowserRouter>
+                                                            <GlobalStyle />
+                                                            <ContentScopeProvider>
+                                                                {({ match }) => (
+                                                                    <Switch>
+                                                                        <Route
+                                                                            path={`${match.path}/preview`}
+                                                                            render={(props) => <SitePreview {...props} />}
+                                                                        />
+                                                                        <Route
+                                                                            render={() => (
+                                                                                <MasterLayout
+                                                                                    headerComponent={MasterHeader}
+                                                                                    menuComponent={() => <MasterMenu menu={masterMenuData} />}
+                                                                                >
+                                                                                    <MasterMenuRoutes menu={masterMenuData} />
+                                                                                </MasterLayout>
+                                                                            )}
+                                                                        />
+                                                                    </Switch>
+                                                                )}
+                                                            </ContentScopeProvider>
+                                                            <ErrorDialogHandler />
+                                                        </RouterBrowserRouter>
+                                                    </ConfigProvider>
                                                 </CmsBlockContextProvider>
                                             </SnackbarProvider>
                                         </DndProvider>

--- a/admin/src/config.tsx
+++ b/admin/src/config.tsx
@@ -1,5 +1,5 @@
 import { SiteConfig } from "@comet/cms-admin";
-import React, { createContext, PropsWithChildren, useContext } from "react";
+import { createContext, PropsWithChildren, useContext } from "react";
 
 import cometConfig from "./comet-config.json";
 import { environment } from "./environment";

--- a/admin/src/config.tsx
+++ b/admin/src/config.tsx
@@ -1,4 +1,5 @@
 import { SiteConfig } from "@comet/cms-admin";
+import React, { createContext, PropsWithChildren, useContext } from "react";
 
 import cometConfig from "./comet-config.json";
 import { environment } from "./environment";
@@ -30,3 +31,19 @@ export function createConfig() {
 export type SitesConfig = Record<string, SiteConfig>;
 
 export type Config = ReturnType<typeof createConfig>;
+
+const ConfigContext = createContext<Config | undefined>(undefined);
+
+export function ConfigProvider({ config, children }: PropsWithChildren<{ config: Config }>) {
+    return <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>;
+}
+
+export function useConfig(): Config {
+    const config = useContext(ConfigContext);
+
+    if (config === undefined) {
+        throw new Error("useConfig must be used within a ConfigProvider");
+    }
+
+    return config;
+}


### PR DESCRIPTION
The config shouldn't be created anew everytime it is needed in a component. Instead, it should be accessed via dependency injection. To achieve that, we add a `ConfigProvider` and `useConfig` hook.

---

COM-638