### PR TITLE
Remove unnecessary React imports in Admin

### DIFF
--- a/admin/.eslintrc.json
+++ b/admin/.eslintrc.json
@@ -1,4 +1,7 @@
 {
     "extends": "@comet/eslint-config/react",
-    "ignorePatterns": ["schema.json", "src/fragmentTypes.json", "src/**/*.generated.ts"]
+    "ignorePatterns": ["schema.json", "src/fragmentTypes.json", "src/**/*.generated.ts"],
+    "rules": {
+        "react/react-in-jsx-scope": "off"
+    }
 }

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -25,7 +25,6 @@ import { css, Global } from "@emotion/react";
 import { ContentScope } from "@src/common/ContentScopeProvider";
 import { getMessages } from "@src/lang";
 import { theme } from "@src/theme";
-import * as React from "react";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { IntlProvider } from "react-intl";

--- a/admin/src/common/ContentScopeProvider.tsx
+++ b/admin/src/common/ContentScopeProvider.tsx
@@ -13,7 +13,6 @@ import {
     useSitesConfig,
 } from "@comet/cms-admin";
 import { SitesConfig } from "@src/config";
-import React from "react";
 
 type Domain = "main" | "secondary" | string;
 type Language = "en" | string;
@@ -39,9 +38,9 @@ const controlsConfig: ContentScopeControlsConfig<ContentScope> = {
 };
 
 // convenince wrapper for app (Bind config and Generic)
-export const ContentScopeControls: React.FC = () => {
+export function ContentScopeControls() {
     return <ContentScopeControlsLibrary<ContentScope> config={controlsConfig} />;
-};
+}
 
 export function useContentScopeConfig(p: ContentScopeConfigProps): void {
     return useContentScopeConfigLibrary(p);

--- a/admin/src/common/MasterHeader.tsx
+++ b/admin/src/common/MasterHeader.tsx
@@ -1,9 +1,8 @@
 import { BuildEntry, Header, UserHeaderItem } from "@comet/cms-admin";
-import * as React from "react";
 
 import { ContentScopeControls } from "./ContentScopeProvider";
 
-export const MasterHeader: React.FC = () => {
+export function MasterHeader() {
     return (
         <Header>
             <ContentScopeControls />
@@ -11,4 +10,4 @@ export const MasterHeader: React.FC = () => {
             <UserHeaderItem />
         </Header>
     );
-};
+}

--- a/admin/src/common/blocks/HeadlineBlock.tsx
+++ b/admin/src/common/blocks/HeadlineBlock.tsx
@@ -1,7 +1,6 @@
 import { BlockCategory, createCompositeBlock, createCompositeBlockSelectField } from "@comet/blocks-admin";
 import { createRichTextBlock } from "@comet/cms-admin";
 import { HeadlineBlockData } from "@src/blocks.generated";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { LinkBlock } from "./LinkBlock";

--- a/admin/src/common/blocks/LinkListBlock.tsx
+++ b/admin/src/common/blocks/LinkListBlock.tsx
@@ -1,5 +1,4 @@
 import { createListBlock } from "@comet/blocks-admin";
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { TextLinkBlock } from "./TextLinkBlock";

--- a/admin/src/common/masterMenuData.tsx
+++ b/admin/src/common/masterMenuData.tsx
@@ -12,7 +12,6 @@ import {
 import { DashboardPage } from "@src/dashboard/DashboardPage";
 import { Link } from "@src/documents/links/Link";
 import { Page } from "@src/documents/pages/Page";
-import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { ContentScopeIndicatorContent, ContentScopeIndicatorDomain, ContentScopeIndicatorLanguage } from "./ContentScopeIndicatorStyles";

--- a/admin/src/dashboard/DashboardPage.tsx
+++ b/admin/src/dashboard/DashboardPage.tsx
@@ -1,7 +1,6 @@
 import { MainContent, Stack } from "@comet/admin";
 import { DashboardHeader, LatestBuildsDashboardWidget } from "@comet/cms-admin";
 import { Grid } from "@mui/material";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
 import backgroundImage1x from "./dashboard-image@1x.jpg";

--- a/admin/src/dashboard/LatestContentUpdates.tsx
+++ b/admin/src/dashboard/LatestContentUpdates.tsx
@@ -3,7 +3,6 @@ import { LatestContentUpdatesDashboardWidget } from "@comet/cms-admin";
 import { useContentScope } from "@src/common/ContentScopeProvider";
 import { GQLLatestContentUpdatesQueryVariables } from "@src/dashboard/LatestContentUpdates.generated";
 import { categoryToUrlParam } from "@src/pageTree/pageTreeCategories";
-import React from "react";
 
 import { GQLLatestContentUpdatesQuery } from "./LatestContentUpdates.generated";
 

--- a/admin/src/documents/links/EditLink.tsx
+++ b/admin/src/documents/links/EditLink.tsx
@@ -5,7 +5,6 @@ import { AdminComponentRoot } from "@comet/blocks-admin";
 import { createUsePage, EditPageLayout, PageName } from "@comet/cms-admin";
 import { IconButton } from "@mui/material";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
-import * as React from "react";
 import { useIntl } from "react-intl";
 
 import { GQLEditLinkQuery, GQLEditLinkQueryVariables, GQLUpdateLinkMutation, GQLUpdateLinkMutationVariables } from "./EditLink.generated";

--- a/admin/src/documents/links/Link.tsx
+++ b/admin/src/documents/links/Link.tsx
@@ -4,7 +4,6 @@ import { createDocumentDependencyMethods, createDocumentRootBlocksMethods, Depen
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import { GQLLink, GQLLinkInput } from "@src/graphql.generated";
 import { categoryToUrlParam } from "@src/pageTree/pageTreeCategories";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { EditLink } from "./EditLink";

--- a/admin/src/documents/pages/EditPage.tsx
+++ b/admin/src/documents/pages/EditPage.tsx
@@ -15,7 +15,6 @@ import {
 import { Button, IconButton, Stack } from "@mui/material";
 import { useContentScope } from "@src/common/ContentScopeProvider";
 import { GQLPageTreeNodeCategory } from "@src/graphql.generated";
-import * as React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useRouteMatch } from "react-router";
 

--- a/admin/src/documents/pages/Page.tsx
+++ b/admin/src/documents/pages/Page.tsx
@@ -3,7 +3,6 @@ import { File, FileNotMenu } from "@comet/admin-icons";
 import { createDocumentDependencyMethods, createDocumentRootBlocksMethods, DependencyInterface, DocumentInterface } from "@comet/cms-admin";
 import { GQLPage, GQLPageInput } from "@src/graphql.generated";
 import { categoryToUrlParam } from "@src/pageTree/pageTreeCategories";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { PageContentBlock } from "./blocks/PageContentBlock";

--- a/admin/src/loader.ts
+++ b/admin/src/loader.ts
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { createElement } from "react";
+import { render } from "react-dom";
 
 import { App } from "./App";
 
@@ -7,7 +7,7 @@ const loadHtml = () => {
     const rootElement = document.querySelector<HTMLElement>("#root");
     if (!rootElement) return false;
 
-    ReactDOM.render(React.createElement(App), rootElement);
+    render(createElement(App), rootElement);
 };
 
 if (["interactive", "complete"].includes(document.readyState)) {

--- a/admin/src/pageTree/pageTreeCategories.tsx
+++ b/admin/src/pageTree/pageTreeCategories.tsx
@@ -1,7 +1,6 @@
 import { AllCategories } from "@comet/cms-admin";
 import { GQLPageTreeNodeCategory } from "@src/graphql.generated";
 import { kebabCase, pascalCase } from "change-case";
-import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 export const pageTreeCategories: AllCategories = [


### PR DESCRIPTION
The React import doesn't have to be in the JSX scope anymore since we're now using the new transform.