### PR TITLE
@comet/create-app remove-site: Fix script after changes in package.json

### DIFF
--- a/create-app/src/scripts/remove-site/removeSite.ts
+++ b/create-app/src/scripts/remove-site/removeSite.ts
@@ -10,6 +10,7 @@ function removeSiteReferences(verbose: boolean) {
     removeReferenceInFile("copy-schema-files.js", /.*site.*\n/gim, verbose);
     removeReferenceInFile("lint-staged.config.js", /.*site.*\n/gim, verbose);
     removeReferenceInFile("./package.json", / browser:site/g, verbose);
+    removeReferenceInFile("./package.json", /site\|create-app/g, verbose);
     removeReferenceInFile("./package.json", /.*site.*\n/gim, verbose);
     removeReferenceInFile("dev-pm.config.js", /{[\n ]*name: "site.*},\n/gis, verbose);
 }

--- a/create-app/src/scripts/remove-site/removeSite.ts
+++ b/create-app/src/scripts/remove-site/removeSite.ts
@@ -10,7 +10,7 @@ function removeSiteReferences(verbose: boolean) {
     removeReferenceInFile("copy-schema-files.js", /.*site.*\n/gim, verbose);
     removeReferenceInFile("lint-staged.config.js", /.*site.*\n/gim, verbose);
     removeReferenceInFile("./package.json", / browser:site/g, verbose);
-    removeReferenceInFile("./package.json", /site\|create-app/g, verbose);
+    removeReferenceInFile("./package.json", /\|site\|create-app/g, verbose);
     removeReferenceInFile("./package.json", /.*site.*\n/gim, verbose);
     removeReferenceInFile("dev-pm.config.js", /{[\n ]*name: "site.*},\n/gis, verbose);
 }


### PR DESCRIPTION
Fixes bug caused by changes in #169, where the lint:root script was modified, resulting in the deletion of the script in the package.json by the remove-site script, leading the program to crash.