### PR TITLE
@comet/create-app: Add options to override repository and branch to clone

### DIFF
--- a/create-app/README.md
+++ b/create-app/README.md
@@ -17,17 +17,25 @@ The following arguments can be passed to customize the project setup:
 
 -   `project-name` (required): Specifies the name of the project. It will be used as the directory name for the project.
 -   `-ni` or `--no-install`: Disables the automatic installation of dependencies.
+-   `-r` or `--repository <repository>`: Repository to clone from. Defaults to `https://github.com/vivid-planet/comet-starter.git`.
+-   `-b` or `--branch <branch>`: Branch to checkout. Defaults to `main`.
 -   `-v` or `--verbose`: Enables extra console logs for verbose output.
 -   `-V` or `--version`: Outputs the version number.
 -   `-h` or `--help`: Display help for the command.
 
-Example usage with arguments:
+#### Example usage with arguments
+
+Create a new Comet app with the name "my-project" and enable verbose logging:
 
 ```bash
 npx @comet/create-app my-project -v
 ```
 
-This command will create a new Comet app with the name "my-project" and enable verbose logging.
+Create a new Comet app with a different repository and branch:
+
+```bash
+npx @comet/create-app my-project -r https://github.com/my-company/comet-starter.git -b next
+```
 
 ### Commands
 

--- a/create-app/src/index.ts
+++ b/create-app/src/index.ts
@@ -22,9 +22,17 @@ void (async () => {
         .argument("<projectName>", "Sets the name of the project.")
         .option("-v, --verbose", "Enables extra console logs for verbose output.")
         .option("-ni, --no-install", "Disables the automatic installation of dependencies.")
+        .option("-r, --repository <repository>", "Repository to clone from.")
+        .option("-b, --branch <branch>", "Branch to checkout.")
         .action((projectName: string, options) => {
             if (isValidProjectName(projectName)) {
-                createApp({ projectName, verbose: options.verbose, install: options.install });
+                createApp({
+                    projectName,
+                    verbose: options.verbose,
+                    install: options.install,
+                    repository: options.repository,
+                    branch: options.branch,
+                });
             } else {
                 program.error("Please provide a valid project name.");
             }

--- a/create-app/src/scripts/create-app/createApp.ts
+++ b/create-app/src/scripts/create-app/createApp.ts
@@ -11,15 +11,17 @@ import { cleanupWorkingDirectory } from "./cleanupWorkingDirectory";
 import { createInitialGitCommit } from "./createInitialGitCommit";
 import { createWorkingDirectoryCopy } from "./createWorkingDirectoryCopy";
 
-interface CommandOptions {
+export interface CreateAppCommandOptions {
     projectName: string;
     verbose: boolean;
     install: boolean;
+    repository?: string;
+    branch?: string;
 }
 
-export async function createApp(commandOptions: CommandOptions) {
+export async function createApp(commandOptions: CreateAppCommandOptions) {
     console.log(`Creating a new Comet app in ${kleur.blue(`${process.cwd()}\n`)}`);
-    createWorkingDirectoryCopy(commandOptions.projectName, commandOptions.verbose);
+    createWorkingDirectoryCopy(commandOptions);
     cleanupReadme(commandOptions.verbose);
     cleanupWorkingDirectory(commandOptions.verbose);
     replacePlaceholder(commandOptions.projectName, commandOptions.verbose);

--- a/create-app/src/scripts/create-app/createWorkingDirectoryCopy.ts
+++ b/create-app/src/scripts/create-app/createWorkingDirectoryCopy.ts
@@ -2,9 +2,16 @@ import { execSync } from "child_process";
 import kleur from "kleur";
 import process from "process";
 
-export function createWorkingDirectoryCopy(projectName: string, verbose: boolean): void {
+import { CreateAppCommandOptions } from "./createApp";
+
+export function createWorkingDirectoryCopy({
+    projectName,
+    repository = "https://github.com/vivid-planet/comet-starter.git",
+    branch = "main",
+    verbose,
+}: Pick<CreateAppCommandOptions, "projectName" | "repository" | "branch" | "verbose">): void {
     try {
-        const clone = `git clone --depth 1 https://github.com/vivid-planet/comet-starter.git ./${projectName}`;
+        const clone = `git clone --depth 1 --branch ${branch} ${repository} ./${projectName}`;
         execSync(clone);
         process.chdir(`./${projectName}`);
         if (verbose) {


### PR DESCRIPTION
Adds new options `--repository` and `--branch` to `@comet/create-app`. This allows developers to specify a custom repository to clone from and branch to checkout.

Use cases:

1. Checkout Starter@next
2. Use a private repository to start with a proprietary version of Starter