### PR TITLE
Disable persisted queries

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -15,7 +15,7 @@ import {
     RedirectsModule,
     UserPermissionsModule,
 } from "@comet/cms-api";
-import { ApolloDriver } from "@nestjs/apollo";
+import { ApolloDriver, ApolloDriverConfig } from "@nestjs/apollo";
 import { DynamicModule, Module } from "@nestjs/common";
 import { Enhancer, GraphQLModule } from "@nestjs/graphql";
 import { DbModule } from "@src/db/db.module";
@@ -45,7 +45,7 @@ export class AppModule {
             imports: [
                 ConfigModule.forRoot(config),
                 DbModule,
-                GraphQLModule.forRootAsync({
+                GraphQLModule.forRootAsync<ApolloDriverConfig>({
                     driver: ApolloDriver,
                     imports: [BlocksModule],
                     useFactory: (dependencies: Record<string, unknown>) => ({
@@ -65,6 +65,7 @@ export class AppModule {
                         buildSchemaOptions: {
                             fieldMiddleware: [BlocksTransformerMiddlewareFactory.create(dependencies)],
                         },
+                        persistedQueries: false,
                     }),
                     inject: [BLOCKS_MODULE_TRANSFORMER_DEPENDENCIES],
                 }),


### PR DESCRIPTION
We don't used persisted queries in our applications. Explicitly disabling it silences a warning about using persisted queries with an unbounded cache.