### PR TITLE
@comet/create-app: Install dependencies via install.sh

### DIFF
--- a/create-app/src/scripts/create-app/cleanupWorkingDirectory.ts
+++ b/create-app/src/scripts/create-app/cleanupWorkingDirectory.ts
@@ -5,4 +5,5 @@ export function cleanupWorkingDirectory(verbose: boolean) {
     deleteFilesAndFolders(["create-app", ".git", ".github", "LICENSE"], verbose);
     removeReferenceInFile("lint-staged.config.js", /.*create-app.*\n/gim, verbose);
     removeReferenceInFile(".vscode/settings.json", /, "create-app"/g, verbose);
+    removeReferenceInFile("install.sh", /^.*create-app.*$/gm, verbose);
 }

--- a/install.sh
+++ b/install.sh
@@ -45,5 +45,6 @@ sh ./admin/intl-update.sh
 npm --prefix admin install
 npm --prefix api install
 npm --prefix site install
+npm --prefix create-app install
 
 mkdir -p ./api/uploads


### PR DESCRIPTION
It annoys me that I always have to manually run `npm install` in create-app/ after updating Comet.