### PR TITLE
Set imgproxy image to version v3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - postgres
 
   imgproxy:
-    image: darthsim/imgproxy:latest
+    image: darthsim/imgproxy:v3
     volumes:
       - ./api/uploads:/uploads:ro
     ports:


### PR DESCRIPTION
Jira: Erweiterung CLI: Update ImgProxy von v2 auf v3

Timr: INFRA-271

Update imgproxy version to use v3 instead of latest