### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @dkarnutsch @fraxachun @johnnyomair @nsams @thomasdax98

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,4 +1,13 @@
 addAssignees: author
 
+addReviewers: true
+
+reviewers:
+  - dkarnutsch
+  - fraxachun
+  - johnnyomair
+  - nsams
+  - thomasdax98
+
 skipKeywords:
   - Merge main into next


### PR DESCRIPTION
Code owners can't be removed as reviewers. Revert back to [Auto Assign](https://github.com/kentaro-m/auto-assign) bot.