### PR TITLE
Use recommended cache header to prevent storing of admin html

### DIFF
--- a/admin/server/server.js
+++ b/admin/server/server.js
@@ -37,8 +37,8 @@ app.use(
         setHeaders: (res, path, stat) => {
             if (path.endsWith(".html")) {
                 // Don't cache the index.html at all to make sure applications updates are applied
-                // implemented as suggested by https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#preventing_caching
-                res.setHeader("cache-control", "no-store, max-age: 0");
+                // implemented as suggested by https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#preventing_storing
+                res.setHeader("cache-control", "no-store");
             } else if (path.endsWith(".js")) {
                 // The js file is static and the index.html uses a parameter as cache buster
                 // implemented as suggested by https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#caching_static_assets


### PR DESCRIPTION
The link is outdated and the header was malformed (using ":" instead of "="). Now we use the suggested header.