### PR TITLE
Admin-Server: Prevent caching of index.html also for fallback

### DIFF
--- a/admin/server/server.js
+++ b/admin/server/server.js
@@ -53,7 +53,7 @@ app.use(
 
 // As a fallback, route everything to index.html
 app.get("*", (req, res) => {
-    res.sendFile(`index.html`, { root: `${__dirname}/../build/` });
+    res.sendFile(`index.html`, { root: `${__dirname}/../build/`, headers: { "cache-control": "no-store" } });
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
Previously, the default cache-control header was used (public, max-age=0), which can lead to caching in certain situations (see https://stackoverflow.com/a/1383359/5562283)

---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [ ] Link to the respective task if one exists: <!-- For instance, COM-123 -->
-   [ ] Provide screenshots/screencasts if the change contains visual changes

<details>
    <summary>Screenshots/screencasts</summary>
    <!-- Insert screenshots/screencasts here -->
</details>
