### PR TITLE
[RFC] Validate scope in GraphQL schema

### DIFF
--- a/admin/src/common/ContentScopeProvider.tsx
+++ b/admin/src/common/ContentScopeProvider.tsx
@@ -13,12 +13,11 @@ import {
     useSitesConfig,
 } from "@comet/cms-admin";
 import { SitesConfig } from "@src/config";
+import { GQLDomain, GQLLanguage } from "@src/graphql.generated";
 
-type Domain = "main" | "secondary" | string;
-type Language = "en" | string;
 export interface ContentScope {
-    domain: Domain;
-    language: Language;
+    domain: GQLDomain;
+    language: GQLLanguage;
 }
 
 // convenince wrapper for app (Bind Generic)
@@ -56,7 +55,7 @@ export const ContentScopeProvider: React.FC<Pick<ContentScopeProviderProps, "chi
         Object.entries(sitesConfig.configs).filter(([siteKey, _siteConfig]) => allowedUserDomains.includes(siteKey)),
     );
     const values: ContentScopeValues<ContentScope> = {
-        domain: Object.keys(allowedSiteConfigs).map((key) => ({ value: key })),
+        domain: Object.keys(allowedSiteConfigs).map((key) => ({ value: key as GQLDomain })),
         language: [
             { label: "English", value: "en" },
             { label: "German", value: "de" },

--- a/api/schema.gql
+++ b/api/schema.gql
@@ -180,8 +180,18 @@ interface DocumentInterface {
 scalar LinkBlockData @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 type PageTreeNodeScope {
-  domain: String!
-  language: String!
+  domain: Domain!
+  language: Language!
+}
+
+enum Domain {
+  main
+  secondary
+}
+
+enum Language {
+  en
+  de
 }
 
 type PageTreeNode {
@@ -339,8 +349,8 @@ type PaginatedDamFolders {
 }
 
 input PageTreeNodeScopeInput {
-  domain: String!
-  language: String!
+  domain: Domain!
+  language: Language!
 }
 
 type Query {

--- a/api/src/page-tree/dto/page-tree-node-scope.ts
+++ b/api/src/page-tree/dto/page-tree-node-scope.ts
@@ -1,18 +1,32 @@
 import { Embeddable, Property } from "@mikro-orm/core";
-import { Field, InputType, ObjectType } from "@nestjs/graphql";
-import { IsString } from "class-validator";
+import { Field, InputType, ObjectType, registerEnumType } from "@nestjs/graphql";
+import { IsEnum } from "class-validator";
+
+enum Domain {
+    main = "main",
+    secondary = "secondary",
+}
+
+registerEnumType(Domain, { name: "Domain" });
+
+enum Language {
+    en = "en",
+    de = "de",
+}
+
+registerEnumType(Language, { name: "Language" });
 
 @Embeddable()
 @ObjectType("PageTreeNodeScope") // name must not be changed in the app
 @InputType("PageTreeNodeScopeInput") // name must not be changed in the app
 export class PageTreeNodeScope {
     @Property({ columnType: "text" })
-    @Field()
-    @IsString()
-    domain: string;
+    @Field(() => Domain)
+    @IsEnum(Domain)
+    domain: Domain;
 
     @Property({ columnType: "text" })
-    @Field()
-    @IsString()
-    language: string;
+    @Field(() => Language)
+    @IsEnum(Language)
+    language: Language;
 }

--- a/site/preBuild/src/publicGenerator/sitemap.xml.ts
+++ b/site/preBuild/src/publicGenerator/sitemap.xml.ts
@@ -4,6 +4,7 @@ import { resolve } from "path";
 import { SitemapStream } from "sitemap";
 
 import { SeoBlockData } from "../../../src/blocks.generated";
+import { GQLDomain, GQLLanguage } from "../../../src/graphql.generated";
 import { createGraphQLClient } from "../../../src/util/createGraphQLClient";
 import { createPublicGeneratedDirectory } from "./createPublicGeneratedDirectory";
 import { GQLSitemapPageDataQuery, GQLSitemapPageDataQueryVariables } from "./sitemap.xml.generated";
@@ -51,9 +52,9 @@ export const sitemapXml = async () => {
 
     smStream.pipe(createWriteStream(resolve(filePath)));
 
-    const domain = process.env.NEXT_PUBLIC_SITE_DOMAIN ?? "";
-    const languages = process.env.NEXT_PUBLIC_SITE_LANGUAGES?.split(",") ?? [];
-    const defaultLanguage = process.env.NEXT_PUBLIC_SITE_DEFAULT_LANGUAGE ?? "";
+    const domain = process.env.NEXT_PUBLIC_SITE_DOMAIN as GQLDomain;
+    const languages = process.env.NEXT_PUBLIC_SITE_LANGUAGES?.split(",") as GQLLanguage[];
+    const defaultLanguage = process.env.NEXT_PUBLIC_SITE_DEFAULT_LANGUAGE as GQLLanguage;
 
     let siteMapEntryCreated = false;
 

--- a/site/src/common/contentScope/ContentScope.tsx
+++ b/site/src/common/contentScope/ContentScope.tsx
@@ -1,6 +1,7 @@
+import { GQLDomain, GQLLanguage } from "@src/graphql.generated";
 import * as React from "react";
 
-type ContentScope = { domain: string; language: string };
+type ContentScope = { domain: GQLDomain; language: GQLLanguage };
 
 const ContentScopeContext = React.createContext<ContentScope | undefined>(undefined);
 

--- a/site/src/common/contentScope/inferContentScopeFromContext.ts
+++ b/site/src/common/contentScope/inferContentScopeFromContext.ts
@@ -1,4 +1,5 @@
 import { defaultLanguage, domain } from "@src/config";
+import { GQLDomain, GQLLanguage } from "@src/graphql.generated";
 import { GetServerSidePropsContext, GetStaticPropsContext } from "next";
 
 import { ContentScope } from "./ContentScope";
@@ -6,10 +7,10 @@ import { ContentScope } from "./ContentScope";
 function inferContentScopeFromContext(context: GetStaticPropsContext | GetServerSidePropsContext): ContentScope {
     if (typeof context.params?.domain === "string" && typeof context.params?.language === "string") {
         // Site preview
-        return { domain: context.params.domain, language: context.params.language };
+        return { domain: context.params.domain as GQLDomain, language: context.params.language as GQLLanguage };
     } else {
         // Live site
-        const language = context.locale ?? defaultLanguage;
+        const language = (context.locale as GQLLanguage) ?? defaultLanguage;
         return { domain, language };
     }
 }

--- a/site/src/config.ts
+++ b/site/src/config.ts
@@ -1,22 +1,24 @@
-export let domain = "";
-export let languages: string[] = [];
-export let defaultLanguage = "";
+import { GQLDomain, GQLLanguage } from "./graphql.generated";
+
+export let domain: GQLDomain;
+export let languages: GQLLanguage[] = [];
+export let defaultLanguage: GQLLanguage;
 
 if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW !== "true") {
     if (process.env.NEXT_PUBLIC_SITE_DOMAIN) {
-        domain = process.env.NEXT_PUBLIC_SITE_DOMAIN;
+        domain = process.env.NEXT_PUBLIC_SITE_DOMAIN as GQLDomain;
     } else {
         throw new Error("Missing environment variable NEXT_PUBLIC_SITE_DOMAIN");
     }
 
     if (process.env.NEXT_PUBLIC_SITE_LANGUAGES) {
-        languages = process.env.NEXT_PUBLIC_SITE_LANGUAGES.split(",");
+        languages = process.env.NEXT_PUBLIC_SITE_LANGUAGES.split(",") as GQLLanguage[];
     } else {
         throw new Error("Missing environment variable NEXT_PUBLIC_SITE_LANGUAGES");
     }
 
     if (process.env.NEXT_PUBLIC_SITE_DEFAULT_LANGUAGE) {
-        defaultLanguage = process.env.NEXT_PUBLIC_SITE_DEFAULT_LANGUAGE;
+        defaultLanguage = process.env.NEXT_PUBLIC_SITE_DEFAULT_LANGUAGE as GQLLanguage;
     } else {
         throw new Error("Missing environment variable NEXT_PUBLIC_SITE_DEFAULT_LANGUAGE");
     }

--- a/site/src/pages/[[...path]].page.tsx
+++ b/site/src/pages/[[...path]].page.tsx
@@ -1,5 +1,5 @@
 import { inferContentScopeFromContext } from "@src/common/contentScope/inferContentScopeFromContext";
-import { domain as configuredDomain } from "@src/config";
+import { domain as configuredDomain, languages } from "@src/config";
 import { Page as PageTypePage, pageQuery as PageTypePageQuery } from "@src/documents/pages/Page";
 import { GQLPage } from "@src/graphql.generated";
 import { getLayout } from "@src/layout/Layout";
@@ -121,12 +121,12 @@ const pagesQuery = gql`
     }
 `;
 
-export const getStaticPaths: GetStaticPaths = async ({ locales = [] }) => {
+export const getStaticPaths: GetStaticPaths = async () => {
     const paths: Array<{ params: { path: string[] }; locale: string }> = [];
     if (process.env.NEXT_PUBLIC_SITE_IS_PREVIEW !== "true") {
-        for (const locale of locales) {
+        for (const language of languages) {
             const data = await createGraphQLClient().request<GQLPagesQuery, GQLPagesQueryVariables>(pagesQuery, {
-                scope: { domain: configuredDomain, language: locale },
+                scope: { domain: configuredDomain, language },
             });
 
             paths.push(
@@ -135,7 +135,7 @@ export const getStaticPaths: GetStaticPaths = async ({ locales = [] }) => {
                     .map((page) => {
                         const path = page.path.split("/");
                         path.shift(); // Remove "" caused by leading slash
-                        return { params: { path }, locale };
+                        return { params: { path }, locale: language };
                     }),
             );
         }

--- a/site/src/pages/_app.page.tsx
+++ b/site/src/pages/_app.page.tsx
@@ -1,5 +1,6 @@
 import { ContentScope, ContentScopeProvider } from "@src/common/contentScope/ContentScope";
 import { defaultLanguage, domain } from "@src/config";
+import { GQLDomain, GQLLanguage } from "@src/graphql.generated";
 import { getMessages } from "@src/lang";
 import { theme } from "@src/theme";
 import { ResponsiveSpacingStyle } from "@src/util/ResponsiveSpacingStyle";
@@ -153,10 +154,10 @@ const getInitialProps: typeof App.getInitialProps = async (appContext) => {
 
     if (typeof appContext.router.query.domain === "string" && typeof appContext.router.query.language === "string") {
         // Site preview
-        scope = { domain: appContext.router.query.domain, language: appContext.router.query.language };
+        scope = { domain: appContext.router.query.domain as GQLDomain, language: appContext.router.query.language as GQLLanguage };
     } else {
         // Live site
-        const language = appContext.router.locale ?? defaultLanguage;
+        const language = (appContext.router.locale as GQLLanguage) ?? defaultLanguage;
         scope = { domain, language };
     }
 


### PR DESCRIPTION
## Motivation

In recent pen tests I've noticed that we don't validate the value of the provide scope dimensions. For instance, one attempt during a pen test failed with a DB driver exception because the provided scope domain was: 

```
a:2:{i:7;O:15:"Zend\Log\Logger":1:{s:10:"*writers";a:1:{i:0;O:20:"Zend\Log\Writer\Mail":3:{s:15:"*eventsToMail";a:1:{i:0;i:0;}s:21:"*subjectPrependText";s:0:"";s:24:"*numEntriesPerPriority";a:1:{i:0;O:14:"Zend\Tag\Cloud":2:{s:7:"*tags";a:1:{i:0;s:0:"";}s:15:"*tagDecorator";O:34:"Zend\Tag\Cloud\Decorator\HtmlCloud":3:{s:12:"*separator";s:0:"";s:10:"*escaper";O:20:"Zend\Escaper\Escaper":1:{s:18:"*htmlAttrMatcher";a:2:{i:0;O:23:"Zend\Filter\FilterChain":1:{s:10:"*filters";O:13:"SplFixedArray":2:{i:0;a:2:{i:0;O:14:"Zend\Json\Expr":1:{s:13:"*expression";s:11:"tenable.was";}i:1;s:10:"__toString";}i:1;s:13:"gethostbyname";}}i:1;s:6:"filter";}}s:11:"*htmlTags";a:1:{s:1:"h";a:1:{s:1:"a";s:1:"!";}}}}}}}}i:7;i:7;}
```

This could be prevented on the GraphQL layer by using more strict types for the content scope, for instance, enums.

## Example

Before: Anything is allowed, API responds with no results (best case)

<img width="1545" alt="before" src="https://github.com/vivid-planet/comet-starter/assets/48853629/fc98b429-451c-4399-a266-84439277e655">

After: Only specific values are allowed, API fails with a validation error (no leaks due to disabling field suggestions)

<img width="1814" alt="after" src="https://github.com/vivid-planet/comet-starter/assets/48853629/6e7d2548-256c-49b3-b737-3aec25502592">

## Alternatives

* Validate using class-validator (only possible by using args classes)
* Ignore

What do you think?