### PR TITLE
RichTextBlock: only render `div` when `disableLastBottomSpacing` is set

### DIFF
--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -145,7 +145,7 @@ export const PageContentRichTextBlock = (props: RichTextBlockProps) => (
     </PageLayout>
 );
 
-const NoLastBottomSpace = styled.div`
+const DisableLastBottomSpacing = styled.div`
     ${({ theme }) =>
         css`
             > *:last-child {

--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -130,7 +130,7 @@ export const RichTextBlock = withPreview(
 
         return (
             <PreviewSkeleton title="RichText" type="rows" hasContent={hasRichTextBlockContent(data)}>
-                {disableLastBottomSpacing ? <NoLastBottomSpace>{rendered}</NoLastBottomSpace> : rendered}
+                {disableLastBottomSpacing ? <DisableLastBottomSpacing>{rendered}</DisableLastBottomSpacing> : rendered}
             </PreviewSkeleton>
         );
     },

--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -145,7 +145,9 @@ export const PageContentRichTextBlock = (props: RichTextBlockProps) => (
     </PageLayout>
 );
 
-const Root = styled.div<{ $disableLastBottomSpacing?: boolean }>`
+const Root = styled.span<{ $disableLastBottomSpacing?: boolean }>`
+    display: block;
+
     ${({ theme, $disableLastBottomSpacing }) =>
         $disableLastBottomSpacing &&
         css`

--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -130,7 +130,7 @@ export const RichTextBlock = withPreview(
 
         return (
             <PreviewSkeleton title="RichText" type="rows" hasContent={hasRichTextBlockContent(data)}>
-                <Root $disableLastBottomSpacing={disableLastBottomSpacing}>{rendered}</Root>
+                {disableLastBottomSpacing ? <NoLastBottomSpace>{rendered}</NoLastBottomSpace> : rendered}
             </PreviewSkeleton>
         );
     },
@@ -145,11 +145,8 @@ export const PageContentRichTextBlock = (props: RichTextBlockProps) => (
     </PageLayout>
 );
 
-const Root = styled.span<{ $disableLastBottomSpacing?: boolean }>`
-    display: block;
-
-    ${({ theme, $disableLastBottomSpacing }) =>
-        $disableLastBottomSpacing &&
+const NoLastBottomSpace = styled.div`
+    ${({ theme }) =>
         css`
             > *:last-child {
                 margin-bottom: 0;


### PR DESCRIPTION
prevents invalid html when div is rendered inside p tag when a Typgraphy is wrapped around the RichTextBlock