### PR TITLE
Prevent schema.gql write in production

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -52,7 +52,7 @@ export class AppModule {
                     useFactory: (dependencies: Record<string, unknown>) => ({
                         debug: config.debug,
                         playground: config.debug,
-                        autoSchemaFile: "schema.gql",
+                        autoSchemaFile: process.env.NODE_ENV === "development" ? "schema.gql" : true,
                         formatError: (error) => {
                             // Disable GraphQL field suggestions in production
                             if (process.env.NODE_ENV !== "development") {

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -52,6 +52,7 @@ export class AppModule {
                     useFactory: (dependencies: Record<string, unknown>) => ({
                         debug: config.debug,
                         playground: config.debug,
+                        // Prevents writing the schema.gql file in production. Necessary for environments with a read-only file system
                         autoSchemaFile: process.env.NODE_ENV === "development" ? "schema.gql" : true,
                         formatError: (error) => {
                             // Disable GraphQL field suggestions in production


### PR DESCRIPTION
Some of our customers use read-only file systems in deployed environments. We therefore can't write the schema.gql file. Disabling it for production shouldn't be a problem, since our only use case (for now) is generating the types for Site and Admin.
