### PR TITLE
Remove next/navigation compat types

### DIFF
--- a/site/next-env.d.ts
+++ b/site/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
Only needed when we both Pages and App Router is used: https://github.com/vercel/next.js/blob/canary/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts#L52-L56.