### PR TITLE
Add `PageLayout` to `StandaloneMediaBlock`

### DIFF
--- a/site/src/common/blocks/StandaloneMediaBlock.tsx
+++ b/site/src/common/blocks/StandaloneMediaBlock.tsx
@@ -2,10 +2,15 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { StandaloneMediaBlockData } from "@src/blocks.generated";
 import { MediaBlock } from "@src/common/blocks/MediaBlock";
+import { PageLayout } from "@src/layout/PageLayout";
 
 export const StandaloneMediaBlock = withPreview(
     ({ data: { media, aspectRatio } }: PropsWithData<StandaloneMediaBlockData>) => {
-        return <MediaBlock data={media} aspectRatio={aspectRatio} />;
+        return (
+            <PageLayout>
+                <MediaBlock data={media} aspectRatio={aspectRatio} />
+            </PageLayout>
+        );
     },
     { label: "Media" },
 );


### PR DESCRIPTION
Prevent media from full width on screens larger than max page layout width