### PR TITLE
Remove legacy behavior for link blocks

### DIFF
--- a/site/src/common/blocks/CallToActionBlock.tsx
+++ b/site/src/common/blocks/CallToActionBlock.tsx
@@ -3,8 +3,9 @@ import { PropsWithData, withPreview } from "@comet/cms-site";
 import { CallToActionBlockData } from "@src/blocks.generated";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import { HiddenIfInvalidLink } from "@src/common/helpers/HiddenIfInvalidLink";
+import styled, { css } from "styled-components";
 
-import { Button, ButtonVariant } from "../components/Button";
+import { ButtonVariant } from "../components/Button";
 
 const buttonVariantMap: Record<CallToActionBlockData["variant"], ButtonVariant> = {
     Contained: "contained",
@@ -15,10 +16,67 @@ const buttonVariantMap: Record<CallToActionBlockData["variant"], ButtonVariant> 
 export const CallToActionBlock = withPreview(
     ({ data: { textLink, variant } }: PropsWithData<CallToActionBlockData>) => (
         <HiddenIfInvalidLink link={textLink.link}>
-            <LinkBlock data={textLink.link}>
-                <Button variant={buttonVariantMap[variant]}>{textLink.text}</Button>
-            </LinkBlock>
+            <Button data={textLink.link} $variant={buttonVariantMap[variant]}>
+                {textLink.text}
+            </Button>
         </HiddenIfInvalidLink>
     ),
     { label: "Call To Action" },
 );
+
+const buttonVariantStyle: Record<ButtonVariant, ReturnType<typeof css>> = {
+    contained: css`
+        ${({ theme }) => css`
+            background-color: ${theme.palette.primary.main};
+            color: ${theme.palette.primary.contrastText};
+            border: 1px solid ${theme.palette.primary.main};
+
+            &:hover {
+                background-color: ${theme.palette.primary.dark};
+                border-color: ${theme.palette.primary.dark};
+            }
+        `}
+    `,
+    outlined: css`
+        ${({ theme }) => css`
+            background-color: transparent;
+            color: ${theme.palette.primary.main};
+            border: 1px solid ${theme.palette.primary.main};
+
+            &:hover {
+                color: ${theme.palette.primary.dark};
+                border-color: ${theme.palette.primary.dark};
+            }
+        `}
+    `,
+    text: css`
+        ${({ theme }) => css`
+            background-color: transparent;
+            color: ${theme.palette.primary.main};
+            border: 1px solid transparent;
+
+            &:hover {
+                color: ${theme.palette.primary.dark};
+            }
+        `}
+    `,
+};
+
+const Button = styled(LinkBlock)<{ $variant: ButtonVariant }>`
+    display: inline-flex;
+    padding: ${({ theme }) => `${theme.spacing.S400} ${theme.spacing.S500}`};
+    border-radius: 4px;
+    cursor: pointer;
+    justify-content: center;
+    align-items: center;
+    transition: background-color 0.2s ease-out, color 0.2s ease-out, border-color 0.2s ease-out;
+
+    text-align: center;
+    text-decoration: none;
+    font-family: ${({ theme }) => theme.fontFamily};
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 110%;
+
+    ${({ $variant }) => buttonVariantStyle[$variant]};
+`;

--- a/site/src/common/blocks/CallToActionBlock.tsx
+++ b/site/src/common/blocks/CallToActionBlock.tsx
@@ -2,10 +2,9 @@
 import { PropsWithData, withPreview } from "@comet/cms-site";
 import { CallToActionBlockData } from "@src/blocks.generated";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
-import { HiddenIfInvalidLink } from "@src/common/helpers/HiddenIfInvalidLink";
-import styled, { css } from "styled-components";
 
-import { ButtonVariant } from "../components/Button";
+import { Button, ButtonVariant } from "../components/Button";
+import { HiddenIfInvalidLink } from "../helpers/HiddenIfInvalidLink";
 
 const buttonVariantMap: Record<CallToActionBlockData["variant"], ButtonVariant> = {
     Contained: "contained",
@@ -16,67 +15,10 @@ const buttonVariantMap: Record<CallToActionBlockData["variant"], ButtonVariant> 
 export const CallToActionBlock = withPreview(
     ({ data: { textLink, variant } }: PropsWithData<CallToActionBlockData>) => (
         <HiddenIfInvalidLink link={textLink.link}>
-            <Button data={textLink.link} $variant={buttonVariantMap[variant]}>
+            <Button as={LinkBlock} data={textLink.link} variant={buttonVariantMap[variant]}>
                 {textLink.text}
             </Button>
         </HiddenIfInvalidLink>
     ),
     { label: "Call To Action" },
 );
-
-const buttonVariantStyle: Record<ButtonVariant, ReturnType<typeof css>> = {
-    contained: css`
-        ${({ theme }) => css`
-            background-color: ${theme.palette.primary.main};
-            color: ${theme.palette.primary.contrastText};
-            border: 1px solid ${theme.palette.primary.main};
-
-            &:hover {
-                background-color: ${theme.palette.primary.dark};
-                border-color: ${theme.palette.primary.dark};
-            }
-        `}
-    `,
-    outlined: css`
-        ${({ theme }) => css`
-            background-color: transparent;
-            color: ${theme.palette.primary.main};
-            border: 1px solid ${theme.palette.primary.main};
-
-            &:hover {
-                color: ${theme.palette.primary.dark};
-                border-color: ${theme.palette.primary.dark};
-            }
-        `}
-    `,
-    text: css`
-        ${({ theme }) => css`
-            background-color: transparent;
-            color: ${theme.palette.primary.main};
-            border: 1px solid transparent;
-
-            &:hover {
-                color: ${theme.palette.primary.dark};
-            }
-        `}
-    `,
-};
-
-const Button = styled(LinkBlock)<{ $variant: ButtonVariant }>`
-    display: inline-flex;
-    padding: ${({ theme }) => `${theme.spacing.S400} ${theme.spacing.S500}`};
-    border-radius: 4px;
-    cursor: pointer;
-    justify-content: center;
-    align-items: center;
-    transition: background-color 0.2s ease-out, color 0.2s ease-out, border-color 0.2s ease-out;
-
-    text-align: center;
-    text-decoration: none;
-    font-family: ${({ theme }) => theme.fontFamily};
-    font-size: 16px;
-    font-weight: 700;
-    line-height: 110%;
-
-    ${({ $variant }) => buttonVariantStyle[$variant]};
-`;

--- a/site/src/common/blocks/InternalLinkBlock.tsx
+++ b/site/src/common/blocks/InternalLinkBlock.tsx
@@ -7,11 +7,17 @@ import * as React from "react";
 interface InternalLinkBlockProps extends PropsWithData<InternalLinkBlockData> {
     children: React.ReactNode;
     title?: string;
+    className?: string;
 }
 
-export function InternalLinkBlock({ data: { targetPage, targetPageAnchor }, children, title }: InternalLinkBlockProps): React.ReactElement {
+export function InternalLinkBlock({
+    data: { targetPage, targetPageAnchor },
+    children,
+    title,
+    className,
+}: InternalLinkBlockProps): React.ReactElement {
     if (!targetPage) {
-        return <>{children}</>;
+        return <span className={className}>{children}</span>;
     }
 
     let href = targetPageAnchor !== undefined ? `${targetPage.path}#${targetPageAnchor}` : targetPage.path;
@@ -23,7 +29,7 @@ export function InternalLinkBlock({ data: { targetPage, targetPageAnchor }, chil
     }
 
     return (
-        <Link href={href} passHref title={title} legacyBehavior>
+        <Link href={href} title={title} className={className}>
             {children}
         </Link>
     );

--- a/site/src/common/blocks/LinkBlock.tsx
+++ b/site/src/common/blocks/LinkBlock.tsx
@@ -15,28 +15,28 @@ import { ReactNode } from "react";
 import { InternalLinkBlock } from "./InternalLinkBlock";
 
 const supportedBlocks: SupportedBlocks = {
-    internal: ({ children, title, ...props }) => (
-        <InternalLinkBlock data={props} title={title}>
+    internal: ({ children, title, className, ...props }) => (
+        <InternalLinkBlock data={props} title={title} className={className}>
             {children}
         </InternalLinkBlock>
     ),
-    external: ({ children, title, ...props }) => (
-        <ExternalLinkBlock data={props} title={title}>
+    external: ({ children, title, className, ...props }) => (
+        <ExternalLinkBlock data={props} title={title} className={className}>
             {children}
         </ExternalLinkBlock>
     ),
-    damFileDownload: ({ children, title, ...props }) => (
-        <DamFileDownloadLinkBlock data={props} title={title}>
+    damFileDownload: ({ children, title, className, ...props }) => (
+        <DamFileDownloadLinkBlock data={props} title={title} className={className}>
             {children}
         </DamFileDownloadLinkBlock>
     ),
-    email: ({ children, title, ...props }) => (
-        <EmailLinkBlock data={props} title={title}>
+    email: ({ children, title, className, ...props }) => (
+        <EmailLinkBlock data={props} title={title} className={className}>
             {children}
         </EmailLinkBlock>
     ),
-    phone: ({ children, title, ...props }) => (
-        <PhoneLinkBlock data={props} title={title}>
+    phone: ({ children, title, className, ...props }) => (
+        <PhoneLinkBlock data={props} title={title} className={className}>
             {children}
         </PhoneLinkBlock>
     ),
@@ -44,12 +44,13 @@ const supportedBlocks: SupportedBlocks = {
 
 interface LinkBlockProps extends PropsWithData<LinkBlockData> {
     children: ReactNode;
+    className?: string;
 }
 
 export const LinkBlock = withPreview(
-    ({ data, children }: LinkBlockProps) => {
+    ({ data, children, className }: LinkBlockProps) => {
         return (
-            <OneOfBlock data={data} supportedBlocks={supportedBlocks}>
+            <OneOfBlock data={data} supportedBlocks={supportedBlocks} className={className}>
                 {children}
             </OneOfBlock>
         );

--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -111,9 +111,9 @@ export const defaultRichTextRenderers: Renderers = {
         // key is the entity key value from raw
         LINK: (children, data: LinkBlockData, { key }) =>
             isValidLink(data) ? (
-                <LinkBlock key={key} data={data}>
-                    <InlineLink>{children}</InlineLink>
-                </LinkBlock>
+                <InlineLink key={key} data={data}>
+                    {children}
+                </InlineLink>
             ) : (
                 <span>{children}</span>
             ),
@@ -173,7 +173,7 @@ const OrderedListItem = styled(Text)<{ $depth: number }>`
     list-style-type: ${({ $depth }) => ($depth % 3 === 1 ? "lower-alpha" : $depth % 3 === 2 ? "lower-roman" : "decimal")};
 `;
 
-const InlineLink = styled.a`
+const InlineLink = styled(LinkBlock)`
     color: ${({ theme }) => theme.palette.primary.main};
     transition: color 0.3s ease-in-out;
 

--- a/site/src/common/blocks/TextLinkBlock.tsx
+++ b/site/src/common/blocks/TextLinkBlock.tsx
@@ -6,11 +6,7 @@ import { LinkBlock } from "./LinkBlock";
 
 export const TextLinkBlock = withPreview(
     ({ data: { link, text } }: PropsWithData<TextLinkBlockData>) => {
-        return (
-            <LinkBlock data={link}>
-                <a>{text}</a>
-            </LinkBlock>
-        );
+        return <LinkBlock data={link}>{text}</LinkBlock>;
     },
     { label: "Text link" },
 );

--- a/site/src/common/components/Button.tsx
+++ b/site/src/common/components/Button.tsx
@@ -18,7 +18,7 @@ export const Button = styled.button<{ variant?: ButtonVariant }>`
     font-weight: 700;
     line-height: 110%;
 
-    ${({ variant = "contained", disabled }) =>
+    ${({ variant = "contained" }) =>
         css`
             ${buttonVariantStyle[variant]}
 
@@ -26,13 +26,6 @@ export const Button = styled.button<{ variant?: ButtonVariant }>`
                 pointer-events: none;
                 ${disabledButtonVariantStyle[variant]};
             }
-
-            /* <a> doesn't support :disabled selector */
-            ${disabled &&
-            css`
-                pointer-events: none;
-                ${disabledButtonVariantStyle[variant]};
-            `}
         `};
 `;
 

--- a/site/src/common/components/Button.tsx
+++ b/site/src/common/components/Button.tsx
@@ -1,26 +1,40 @@
-import { forwardRef, HTMLAttributes, RefObject } from "react";
 import styled, { css } from "styled-components";
 
 export type ButtonVariant = "contained" | "outlined" | "text";
 
-type ButtonProps = {
-    variant?: ButtonVariant;
-    disabled?: boolean;
-} & (HTMLAttributes<HTMLButtonElement> | (HTMLAttributes<HTMLAnchorElement> & Pick<HTMLAnchorElement, "href" | "target">));
+export const Button = styled.button<{ variant?: ButtonVariant }>`
+    display: inline-flex;
+    padding: ${({ theme }) => `${theme.spacing.S400} ${theme.spacing.S500}`};
+    border-radius: 4px;
+    cursor: pointer;
+    justify-content: center;
+    align-items: center;
+    transition: background-color 0.2s ease-out, color 0.2s ease-out, border-color 0.2s ease-out;
 
-export const Button = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
-    ({ variant = "contained", disabled = false, children, ...htmlAttributes }, ref) => {
-        return "href" in htmlAttributes ? (
-            <StyledAnchor ref={ref as RefObject<HTMLAnchorElement>} $variant={variant} $disabled={disabled} {...htmlAttributes}>
-                {children}
-            </StyledAnchor>
-        ) : (
-            <StyledButton ref={ref as RefObject<HTMLButtonElement>} $variant={variant} disabled={disabled} {...htmlAttributes}>
-                {children}
-            </StyledButton>
-        );
-    },
-);
+    text-align: center;
+    text-decoration: none;
+    font-family: ${({ theme }) => theme.fontFamily};
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 110%;
+
+    ${({ variant = "contained", disabled }) =>
+        css`
+            ${buttonVariantStyle[variant]}
+
+            &:disabled {
+                pointer-events: none;
+                ${disabledButtonVariantStyle[variant]};
+            }
+
+            /* <a> doesn't support :disabled selector */
+            ${disabled &&
+            css`
+                pointer-events: none;
+                ${disabledButtonVariantStyle[variant]};
+            `}
+        `};
+`;
 
 const buttonVariantStyle: Record<ButtonVariant, ReturnType<typeof css>> = {
     contained: css`
@@ -78,42 +92,3 @@ const disabledButtonVariantStyle: Record<ButtonVariant, ReturnType<typeof css>> 
         color: ${({ theme }) => theme.palette.grey["300"]};
     `,
 };
-
-const commonButtonStyle = css<{ $variant: ButtonVariant }>`
-    display: inline-flex;
-    padding: ${({ theme }) => `${theme.spacing.S400} ${theme.spacing.S500}`};
-    border-radius: 4px;
-    cursor: pointer;
-    justify-content: center;
-    align-items: center;
-    transition: background-color 0.2s ease-out, color 0.2s ease-out, border-color 0.2s ease-out;
-
-    text-align: center;
-    text-decoration: none;
-    font-family: ${({ theme }) => theme.fontFamily};
-    font-size: 16px;
-    font-weight: 700;
-    line-height: 110%;
-
-    ${({ $variant }) => buttonVariantStyle[$variant]};
-`;
-
-const StyledAnchor = styled.a<{ $variant: ButtonVariant; $disabled: boolean }>`
-    ${commonButtonStyle};
-
-    ${({ $variant, $disabled }) =>
-        $disabled &&
-        css`
-            pointer-events: none;
-            ${disabledButtonVariantStyle[$variant]};
-        `}
-`;
-
-const StyledButton = styled.button<{ $variant: ButtonVariant }>`
-    ${commonButtonStyle};
-
-    &:disabled {
-        pointer-events: none;
-        ${({ $variant }) => disabledButtonVariantStyle[$variant]};
-    }
-`;

--- a/site/src/layout/header/Header.tsx
+++ b/site/src/layout/header/Header.tsx
@@ -18,12 +18,16 @@ function Header({ header }: Props): JSX.Element {
                 <TopLevelNavigation>
                     {header.map((node) => (
                         <TopLevelLinkContainer key={node.id}>
-                            <PageLink page={node}>{(active) => <Link $active={active}>{node.name}</Link>}</PageLink>
+                            <Link page={node} activeClassName="active">
+                                {node.name}
+                            </Link>
                             {node.childNodes.length > 0 && (
                                 <SubLevelNavigation>
                                     {node.childNodes.map((node) => (
                                         <li key={node.id}>
-                                            <PageLink page={node}>{(active) => <Link $active={active}>{node.name}</Link>}</PageLink>
+                                            <Link page={node} activeClassName="active">
+                                                {node.name}
+                                            </Link>
                                         </li>
                                     ))}
                                 </SubLevelNavigation>
@@ -68,12 +72,16 @@ const TopLevelLinkContainer = styled.li`
     }
 `;
 
-const Link = styled.a<{ $active: boolean }>`
+const Link = styled(PageLink)`
     text-decoration: none;
     padding: 5px 10px;
 
     &:hover {
         text-decoration: underline;
+    }
+
+    &.active {
+        color: ${({ theme }) => theme.palette.primary.main};
     }
 `;
 

--- a/site/src/layout/header/PageLink.tsx
+++ b/site/src/layout/header/PageLink.tsx
@@ -3,18 +3,26 @@ import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import { HiddenIfInvalidLink } from "@src/common/helpers/HiddenIfInvalidLink";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import * as React from "react";
+import { ReactNode } from "react";
 
 import { GQLPageLinkFragment } from "./PageLink.fragment.generated";
 
 interface Props {
     page: GQLPageLinkFragment;
-    children: ((active: boolean) => React.ReactNode) | React.ReactNode;
+    children: ReactNode;
+    className?: string;
+    activeClassName?: string;
 }
 
-function PageLink({ page, children }: Props): JSX.Element | null {
+function PageLink({ page, children, className: passedClassName, activeClassName }: Props): JSX.Element | null {
     const pathname = usePathname();
-    const active = pathname === page.path;
+    const active = pathname && (pathname.substring(3) || "/") === page.path; // Remove language prefix
+
+    let className = passedClassName;
+
+    if (active) {
+        className = className ? `${className} ${activeClassName}` : activeClassName;
+    }
 
     if (page.documentType === "Link") {
         if (page.document === null || page.document.__typename !== "Link") {
@@ -23,13 +31,15 @@ function PageLink({ page, children }: Props): JSX.Element | null {
 
         return (
             <HiddenIfInvalidLink link={page.document.content}>
-                <LinkBlock data={page.document.content}>{typeof children === "function" ? children(active) : children}</LinkBlock>
+                <LinkBlock data={page.document.content} className={className}>
+                    {children}
+                </LinkBlock>
             </HiddenIfInvalidLink>
         );
     } else if (page.documentType === "Page") {
         return (
-            <Link href={`/${page.scope.language}${page.path}`} passHref legacyBehavior>
-                {typeof children === "function" ? children(active) : children}
+            <Link href={`/${page.scope.language}${page.path}`} className={className}>
+                {children}
             </Link>
         );
     } else {


### PR DESCRIPTION
Since Next 13 the `Link` component no longer requires a child `<a>` tag by default. This new behavior is now used by our `InternalLinkBlock`, which uses `Link` internally. To ensure that all other link blocks (e.g., `ExternalLinkBlock`) can be styled in the application, we now render an `<a>` tag for all those blocks.

This change adds the `className` prop to the `LinkBlock` to allow styling the block. All link block usages have been adapted to directly style the block.

---

COM-936
