### PR TITLE
Remove heading and margins from `KeyFactsBlock`

### DIFF
--- a/admin/src/documents/pages/blocks/KeyFactsBlock.tsx
+++ b/admin/src/documents/pages/blocks/KeyFactsBlock.tsx
@@ -1,32 +1,11 @@
-import { BlockCategory, createCompositeBlock, createListBlock } from "@comet/blocks-admin";
-import { HeadingBlock } from "@src/common/blocks/HeadingBlock";
+import { createListBlock } from "@comet/blocks-admin";
 import { KeyFactsItemBlock } from "@src/documents/pages/blocks/KeyFactsItemBlock";
 import { FormattedMessage } from "react-intl";
 
-const KeyFactsItemsBlock = createListBlock({
-    name: "KeyFactsItems",
-    displayName: <FormattedMessage id="keyFactsItemsBlock.displayName" defaultMessage="Key facts items" />,
+export const KeyFactsBlock = createListBlock({
+    name: "KeyFacts",
+    displayName: <FormattedMessage id="keyFactsItemsBlock.displayName" defaultMessage="Key facts" />,
     block: KeyFactsItemBlock,
-    itemName: <FormattedMessage id="keyFactsItemsBlock.itemName" defaultMessage="key fact" />,
-    itemsName: <FormattedMessage id="keyFactsItemsBlock.itemsName" defaultMessage="key facts" />,
+    itemName: <FormattedMessage id="keyFactsItemsBlock.itemName" defaultMessage="item" />,
+    itemsName: <FormattedMessage id="keyFactsItemsBlock.itemsName" defaultMessage="items" />,
 });
-
-export const KeyFactsBlock = createCompositeBlock(
-    {
-        name: "KeyFacts",
-        displayName: <FormattedMessage id="keyFactsBlock.displayName" defaultMessage="Key Facts" />,
-        blocks: {
-            heading: {
-                block: HeadingBlock,
-            },
-            items: {
-                block: KeyFactsItemsBlock,
-                title: <FormattedMessage id="keyFactsBlock.items" defaultMessage="Key facts" />,
-            },
-        },
-    },
-    (block) => {
-        block.category = BlockCategory.TextAndContent;
-        return block;
-    },
-);

--- a/admin/src/documents/pages/blocks/KeyFactsItemBlock.tsx
+++ b/admin/src/documents/pages/blocks/KeyFactsItemBlock.tsx
@@ -1,4 +1,4 @@
-import { createCompositeBlock, createCompositeBlockTextField } from "@comet/blocks-admin";
+import { BlockCategory, createCompositeBlock, createCompositeBlockTextField } from "@comet/blocks-admin";
 import { createRichTextBlock, SvgImageBlock } from "@comet/cms-admin";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import { FormattedMessage } from "react-intl";
@@ -38,6 +38,7 @@ export const KeyFactsItemBlock = createCompositeBlock(
         },
     },
     (block) => {
+        block.category = BlockCategory.TextAndContent;
         block.previewContent = (state) => [{ type: "text", content: state.fact }];
         return block;
     },

--- a/api/block-meta.json
+++ b/api/block-meta.json
@@ -844,29 +844,55 @@
         "name": "KeyFacts",
         "fields": [
             {
-                "name": "heading",
-                "kind": "Block",
-                "block": "Heading",
-                "nullable": false
-            },
-            {
-                "name": "items",
-                "kind": "Block",
-                "block": "KeyFactsItems",
+                "name": "blocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "key",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "visible",
+                            "kind": "Boolean",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "Block",
+                            "block": "KeyFactsItem",
+                            "nullable": false
+                        }
+                    ]
+                },
                 "nullable": false
             }
         ],
         "inputFields": [
             {
-                "name": "heading",
-                "kind": "Block",
-                "block": "Heading",
-                "nullable": false
-            },
-            {
-                "name": "items",
-                "kind": "Block",
-                "block": "KeyFactsItems",
+                "name": "blocks",
+                "kind": "NestedObjectList",
+                "object": {
+                    "fields": [
+                        {
+                            "name": "key",
+                            "kind": "String",
+                            "nullable": false
+                        },
+                        {
+                            "name": "visible",
+                            "kind": "Boolean",
+                            "nullable": false
+                        },
+                        {
+                            "name": "props",
+                            "kind": "Block",
+                            "block": "KeyFactsItem",
+                            "nullable": false
+                        }
+                    ]
+                },
                 "nullable": false
             }
         ]
@@ -918,63 +944,6 @@
                 "name": "description",
                 "kind": "Block",
                 "block": "RichText",
-                "nullable": false
-            }
-        ]
-    },
-    {
-        "name": "KeyFactsItems",
-        "fields": [
-            {
-                "name": "blocks",
-                "kind": "NestedObjectList",
-                "object": {
-                    "fields": [
-                        {
-                            "name": "key",
-                            "kind": "String",
-                            "nullable": false
-                        },
-                        {
-                            "name": "visible",
-                            "kind": "Boolean",
-                            "nullable": false
-                        },
-                        {
-                            "name": "props",
-                            "kind": "Block",
-                            "block": "KeyFactsItem",
-                            "nullable": false
-                        }
-                    ]
-                },
-                "nullable": false
-            }
-        ],
-        "inputFields": [
-            {
-                "name": "blocks",
-                "kind": "NestedObjectList",
-                "object": {
-                    "fields": [
-                        {
-                            "name": "key",
-                            "kind": "String",
-                            "nullable": false
-                        },
-                        {
-                            "name": "visible",
-                            "kind": "Boolean",
-                            "nullable": false
-                        },
-                        {
-                            "name": "props",
-                            "kind": "Block",
-                            "block": "KeyFactsItem",
-                            "nullable": false
-                        }
-                    ]
-                },
                 "nullable": false
             }
         ]

--- a/api/src/documents/pages/blocks/key-facts.block.ts
+++ b/api/src/documents/pages/blocks/key-facts.block.ts
@@ -1,37 +1,4 @@
-import {
-    BlockData,
-    BlockDataInterface,
-    BlockInput,
-    ChildBlock,
-    ChildBlockInput,
-    createBlock,
-    createListBlock,
-    ExtractBlockInput,
-    inputToData,
-} from "@comet/blocks-api";
-import { HeadingBlock } from "@src/common/blocks/heading.block";
+import { createListBlock } from "@comet/blocks-api";
 import { KeyFactsItemBlock } from "@src/documents/pages/blocks/key-facts-item.block";
 
-const KeyFactsItemsBlock = createListBlock({ block: KeyFactsItemBlock }, "KeyFactsItems");
-
-class KeyFactsBlockData extends BlockData {
-    @ChildBlock(HeadingBlock)
-    heading: BlockDataInterface;
-
-    @ChildBlock(KeyFactsItemsBlock)
-    items: BlockDataInterface;
-}
-
-class KeyFactsBlockInput extends BlockInput {
-    @ChildBlockInput(HeadingBlock)
-    heading: ExtractBlockInput<typeof HeadingBlock>;
-
-    @ChildBlockInput(KeyFactsItemsBlock)
-    items: ExtractBlockInput<typeof KeyFactsItemsBlock>;
-
-    transformToBlockData(): KeyFactsBlockData {
-        return inputToData(KeyFactsBlockData, this);
-    }
-}
-
-export const KeyFactsBlock = createBlock(KeyFactsBlockData, KeyFactsBlockInput, "KeyFacts");
+export const KeyFactsBlock = createListBlock({ block: KeyFactsItemBlock }, "KeyFacts");

--- a/site/src/documents/pages/blocks/KeyFactsBlock.tsx
+++ b/site/src/documents/pages/blocks/KeyFactsBlock.tsx
@@ -1,18 +1,16 @@
 import { ListBlock, PropsWithData, withPreview } from "@comet/cms-site";
 import { KeyFactsBlockData } from "@src/blocks.generated";
-import { HeadingBlock } from "@src/common/blocks/HeadingBlock";
 import { PageLayout } from "@src/layout/PageLayout";
 import styled, { css } from "styled-components";
 
 import { KeyFactItemBlock } from "./KeyFactItemBlock";
 
 export const KeyFactsBlock = withPreview(
-    ({ data: { heading, items } }: PropsWithData<KeyFactsBlockData>) => (
+    ({ data }: PropsWithData<KeyFactsBlockData>) => (
         <PageLayout grid>
             <PageLayoutContent>
-                <HeadingBlock data={heading} />
-                <ItemWrapper $listItemCount={items.blocks.length}>
-                    <ListBlock data={items} block={(block) => <KeyFactItemBlock data={block} />} />
+                <ItemWrapper $listItemCount={data.blocks.length}>
+                    <ListBlock data={data} block={(block) => <KeyFactItemBlock data={block} />} />
                 </ItemWrapper>
             </PageLayoutContent>
         </PageLayout>
@@ -22,11 +20,9 @@ export const KeyFactsBlock = withPreview(
 
 const PageLayoutContent = styled.div`
     grid-column: 3 / -3;
-    margin: ${({ theme }) => theme.spacing.D300} 0;
 `;
 
 const ItemWrapper = styled.div<{ $listItemCount: number }>`
-    margin-top: ${({ theme }) => theme.spacing.D200};
     display: grid;
     gap: ${({ theme }) => theme.spacing.D100};
 


### PR DESCRIPTION
We decided to remove the heading block and the margins top/bottom from the `KeyFactsBlock`. We try the "do it yourself" way and give to content creators freedom wich spacing they want to use.