### PR TITLE
Disable last bottom spacing for `RichTextBlock` in page content

### DIFF
--- a/site/src/documents/pages/blocks/PageContentBlock.tsx
+++ b/site/src/documents/pages/blocks/PageContentBlock.tsx
@@ -15,7 +15,7 @@ const supportedBlocks: SupportedBlocks = {
     accordion: (props) => <PageContentAccordionBlock data={props} />,
     anchor: (props) => <AnchorBlock data={props} />,
     space: (props) => <SpaceBlock data={props} />,
-    richtext: (props) => <PageContentRichTextBlock data={props} />,
+    richtext: (props) => <PageContentRichTextBlock data={props} disableLastBottomSpacing />,
     heading: (props) => <PageContentHeadingBlock data={props} />,
     columns: (props) => <ColumnsBlock data={props} />,
     callToActionList: (props) => <PageContentCallToActionListBlock data={props} />,


### PR DESCRIPTION
We decided to remove the margins top/bottom from the Page Content Blocks. We try the "do it yourself" way and give to content creators freedom wich spacing they want to use.
