### PR TITLE
Fix Jaeger tracing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,6 @@ services:
       - ${JAEGER_OLTP_PORT}:4318 #OLTP over HTTP
     environment:
       COLLECTOR_OTLP_ENABLED: "true"
-      COLLECTOR_OTLP_GRPC_HOST_PORT: 0.0.0.0:4317
       COLLECTOR_OTLP_HTTP_HOST_PORT: 0.0.0.0:4318
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,12 +35,14 @@ services:
       AWS_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
 
   jaeger:
-    image: jaegertracing/all-in-one:1.58
+    image: jaegertracing/all-in-one:1
     ports:
       - ${JAEGER_UI_PORT}:16686
       - ${JAEGER_OLTP_PORT}:4318 #OLTP over HTTP
     environment:
       COLLECTOR_OTLP_ENABLED: "true"
+      COLLECTOR_OTLP_GRPC_HOST_PORT: 0.0.0.0:4317
+      COLLECTOR_OTLP_HTTP_HOST_PORT: 0.0.0.0:4318
 
 networks:
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       AWS_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
 
   jaeger:
-    image: jaegertracing/all-in-one:1
+    image: jaegertracing/all-in-one:1.58
     ports:
       - ${JAEGER_UI_PORT}:16686
       - ${JAEGER_OLTP_PORT}:4318 #OLTP over HTTP


### PR DESCRIPTION
Due to a recent change in the OpenTelemetry Collector, Jaeger didn't accept OpenTelemetry data anymore. Until this change is reverted upstream, we explicitly pass the the host IP to Jaeger as a workaround. See https://github.com/jaegertracing/jaeger/issues/5737 for more information.
