### PR TITLE
Remove obsolete `next export` script

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,6 @@
         "dev": "npm run intl:compile && run-s gql:types generate-block-types && NODE_OPTIONS='--inspect=localhost:9230' dotenv -e .env -e .env.local -e .env.secrets -e .env.site-configs -- node server.js",
         "build": "npm run intl:compile && run-p gql:types generate-block-types && next build",
         "serve": "NODE_ENV=production node server.js",
-        "export": "next export",
         "gql:types": "graphql-codegen",
         "gql:watch": "graphql-codegen --watch",
         "prelint": "npm run intl:compile && run-p gql:types generate-block-types",


### PR DESCRIPTION
With Next 14 `next export` has been removed in favor of 'output: export' in next.config.js.
