### PR TITLE
`CallToActionList`: do not render empty div when no elements are available

### DIFF
--- a/site/src/common/blocks/CallToActionListBlock.tsx
+++ b/site/src/common/blocks/CallToActionListBlock.tsx
@@ -8,11 +8,12 @@ import styled from "styled-components";
 type CallToActionListBlockProps = PropsWithData<CallToActionListBlockData>;
 
 export const CallToActionListBlock = withPreview(
-    ({ data }: CallToActionListBlockProps) => (
-        <Root>
-            <ListBlock data={data} block={(block) => <CallToActionBlock data={block} />} />
-        </Root>
-    ),
+    ({ data }: CallToActionListBlockProps) =>
+        data.blocks.length > 0 ? (
+            <Root>
+                <ListBlock data={data} block={(block) => <CallToActionBlock data={block} />} />
+            </Root>
+        ) : null,
     { label: "Call To Action List" },
 );
 


### PR DESCRIPTION
`CallToActionList`: do not render empty div when no elements are available