### PR TITLE
Fix next/previous icons in media gallery block

### DIFF
--- a/site/src/common/blocks/MediaGalleryBlock.tsx
+++ b/site/src/common/blocks/MediaGalleryBlock.tsx
@@ -101,8 +101,7 @@ const SwiperWrapper = styled(Swiper)<{ $aspectRatioHorizontal: string; $aspectRa
             height: inherit;
             display: block;
 
-            /* ToDo: change to "/assets/icons/.." when MR https://github.com/vivid-planet/comet-starter/pull/283 is merged */
-            mask-image: url("/icons/arrow-right.svg");
+            mask-image: url("/assets/icons/arrow-right.svg");
             mask-repeat: no-repeat;
             background-color: ${({ theme }) => theme.palette.primary.main};
         }


### PR DESCRIPTION
We need to change the icon path now that #283 has been merged.