### PR TITLE
API: make psql SSL config more flexible

### DIFF
--- a/api/src/config/environment-variables.ts
+++ b/api/src/config/environment-variables.ts
@@ -13,6 +13,10 @@ export class EnvironmentVariables {
     @Transform(({ value }) => value === "true")
     POSTGRESQL_USE_SSL: boolean;
 
+    @IsOptional()
+    @IsString()
+    POSTGRESQL_CA_CERT?: string;
+
     @Type(() => Number)
     @IsInt()
     POSTGRESQL_PORT: number;

--- a/api/src/db/ormconfig.ts
+++ b/api/src/db/ormconfig.ts
@@ -10,7 +10,7 @@ export const ormConfig = createOrmConfig({
     password: process.env.POSTGRESQL_PASSWORD,
     dbName: process.env.POSTGRESQL_DB,
     driverOptions: {
-        connection: { ssl: process.env.POSTGRESQL_USE_SSL === "true" },
+        connection: { ssl: process.env.POSTGRESQL_USE_SSL === "true" ? { rejectUnauthorized: true, ca: process.env.POSTGRESQL_CA_CERT } : false },
     },
     namingStrategy: EntityCaseNamingStrategy,
     debug: false,


### PR DESCRIPTION
This works (verified) for our three main scenarios:
- Without SSL, e.g locally: SSL is disabled (`POSTGRESQL_USE_SSL` is false or undefined) 
- With SSL - no self-signed certificate, e.g Azure: SSL is enabled but no custom CA used (`POSTGRESQL_USE_SSL` is true and `POSTGRESQL_CA_CERT` is undefined)
- With SSL - with self-signed certificate, e.g. DigitalOcean: SSL is enabled and custom CA cert can be set using `POSTGRESQL_CA_CERT` (`POSTGRESQL_USE_SSL` is true and `POSTGRESQL_CA_CERT` is set)