### PR TITLE
Fix Rerendering Bug in MasterMenu

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -30,7 +30,7 @@ import { Route, Switch } from "react-router";
 import { createApolloClient } from "./common/apollo/createApolloClient";
 import { ContentScopeProvider } from "./common/ContentScopeProvider";
 import { MasterHeader } from "./common/MasterHeader";
-import { MasterMenu, masterMenuData, pageTreeCategories, pageTreeDocumentTypes } from "./common/MasterMenu";
+import { AppMasterMenu, masterMenuData, pageTreeCategories, pageTreeDocumentTypes } from "./common/MasterMenu";
 import { ConfigProvider, createConfig } from "./config";
 import { Link } from "./documents/links/Link";
 import { Page } from "./documents/pages/Page";
@@ -116,7 +116,7 @@ export function App() {
                                                                             render={() => (
                                                                                 <MasterLayout
                                                                                     headerComponent={MasterHeader}
-                                                                                    menuComponent={MasterMenu}
+                                                                                    menuComponent={AppMasterMenu}
                                                                                 >
                                                                                     <MasterMenuRoutes menu={masterMenuData} />
                                                                                 </MasterLayout>

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -14,7 +14,6 @@ import {
     CurrentUserProvider,
     DependenciesConfigProvider,
     LocaleProvider,
-    MasterMenu,
     MasterMenuRoutes,
     SitePreview,
     SitesConfigProvider,
@@ -31,7 +30,7 @@ import { Route, Switch } from "react-router";
 import { createApolloClient } from "./common/apollo/createApolloClient";
 import { ContentScopeProvider } from "./common/ContentScopeProvider";
 import { MasterHeader } from "./common/MasterHeader";
-import { masterMenuData, pageTreeCategories, pageTreeDocumentTypes } from "./common/masterMenuData";
+import { MasterMenu, masterMenuData, pageTreeCategories, pageTreeDocumentTypes } from "./common/MasterMenu";
 import { ConfigProvider, createConfig } from "./config";
 import { Link } from "./documents/links/Link";
 import { Page } from "./documents/pages/Page";
@@ -117,7 +116,7 @@ export function App() {
                                                                             render={() => (
                                                                                 <MasterLayout
                                                                                     headerComponent={MasterHeader}
-                                                                                    menuComponent={() => <MasterMenu menu={masterMenuData} />}
+                                                                                    menuComponent={MasterMenu}
                                                                                 >
                                                                                     <MasterMenuRoutes menu={masterMenuData} />
                                                                                 </MasterLayout>

--- a/admin/src/common/MasterMenu.tsx
+++ b/admin/src/common/MasterMenu.tsx
@@ -4,6 +4,7 @@ import {
     ContentScopeIndicator,
     createRedirectsPage,
     DamPage,
+    MasterMenu as CometMasterMenu,
     MasterMenuData,
     PagesPage,
     PublisherPage,
@@ -102,3 +103,5 @@ export const masterMenuData: MasterMenuData = [
         requiredPermission: "pageTree",
     },
 ];
+
+export const MasterMenu = () => <CometMasterMenu menu={masterMenuData} />;

--- a/admin/src/common/MasterMenu.tsx
+++ b/admin/src/common/MasterMenu.tsx
@@ -4,7 +4,7 @@ import {
     ContentScopeIndicator,
     createRedirectsPage,
     DamPage,
-    MasterMenu as CometMasterMenu,
+    MasterMenu,
     MasterMenuData,
     PagesPage,
     PublisherPage,
@@ -104,4 +104,4 @@ export const masterMenuData: MasterMenuData = [
     },
 ];
 
-export const MasterMenu = () => <CometMasterMenu menu={masterMenuData} />;
+export const AppMasterMenu = () => <MasterMenu menu={masterMenuData} />;


### PR DESCRIPTION
## Previously

The MasterMenu was reset completely on every site change, closing open collapsibles


https://github.com/user-attachments/assets/83ee4a75-8d89-4373-a74f-e213c60a15c0



## Now

The MasterMenu is not reset anymore. Open collapsibles stay open


https://github.com/user-attachments/assets/05af2c39-7196-454d-a363-709d8d844773



---

<!-- Everything below this line will be removed from the commit message when the PR is merged -->

## PR Checklist

-   [x] Link to the respective task if one exists: COM-1042
