### PR TITLE
Provide fallback for IntlProvider

### DIFF
--- a/site/src/app/[domain]/[language]/layout.tsx
+++ b/site/src/app/[domain]/[language]/layout.tsx
@@ -1,4 +1,5 @@
 import { IntlProvider } from "@src/app/[domain]/[language]/IntlProvider";
+import { getSiteConfigForDomain } from "@src/util/siteConfig";
 import { readFile } from "fs/promises";
 import { PropsWithChildren } from "react";
 
@@ -11,7 +12,12 @@ async function loadMessages(language: string) {
     return messages;
 }
 
-export default async function Page({ children, params: { language } }: PropsWithChildren<{ params: { language: string } }>) {
+export default async function Page({ children, params: { domain, language } }: PropsWithChildren<{ params: { domain: string; language: string } }>) {
+    const siteConfig = getSiteConfigForDomain(domain);
+    if (!siteConfig.scope.languages.includes(language)) {
+        language = "en";
+    }
+
     const messages = await loadMessages(language);
     return (
         <IntlProvider locale={language} messages={messages}>


### PR DESCRIPTION
Currently the application cannot serve a correct 404. When calling an URL with a wrong language identifier (e.g. /foo instead /en) the page is being rendered and thus the layouts as well. However, the layout returns a 500 because the messages can't be loaded.

With this change the 404 is returned in english if the language can't be resolved.