### PR TITLE
Make local dev more similar to deployed instances

### DIFF
--- a/.env
+++ b/.env
@@ -38,6 +38,7 @@ API_PORT=4000
 API_URL=http://${DEV_DOMAIN:-localhost}:${API_PORT}/api
 API_URL_INTERNAL=http://localhost:$API_PORT/api
 CORS_ALLOWED_ORIGIN="^http:\/\/(localhost|.*\.dev\.vivid-planet\.cloud|192\.168\.\d{1,3}\.\d{1,3}):\d{2,4}"
+BASIC_AUTH_SYSTEM_USER_PASSWORD=password
 
 # blob storage
 BLOB_STORAGE_DRIVER="file"
@@ -55,6 +56,7 @@ SITE_URL=http://${DEV_DOMAIN:-localhost}:${SITE_PORT}
 NEXT_PUBLIC_GTM_ID=
 NEXT_PUBLIC_SITE_URL=$SITE_URL
 NEXT_PUBLIC_API_URL=$API_URL
+API_BASIC_AUTH_SYSTEM_USER_PASSWORD=$BASIC_AUTH_SYSTEM_USER_PASSWORD
 
 # jaegertracing
 JAEGER_UI_PORT=16686

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -54,7 +54,7 @@ export class AuthModule {
             );
             providers.push({
                 provide: APP_GUARD,
-                useClass: createCometAuthGuard(["static-authed-user", "system-user"]),
+                useClass: createCometAuthGuard(["system-user", "static-authed-user"]),
             });
         }
 


### PR DESCRIPTION
The API always uses the static authed user, also during rendering of the site. When the site tries to render a page it calls pageTreeNodeByPath of the API alongside with the current scope. If a "wrong" scope (e.g. a language which does not exist) is sent, the API locally returns an access forbidden because the current authed user does not have access to this scope.

With this PR the API locally uses the system user for these types of requests thus return a valid response allowing the site to call notFound().

COM-681