### PR TITLE
Update GitHub actions versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - run: echo "${{ github.actor }}"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
@@ -29,28 +29,28 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: "Admin: Clone library translations"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: vivid-planet/comet-lang
           token: ${{ secrets.GITHUB_TOKEN }}
           path: "admin/lang/comet-lang"
 
       - name: "Admin: Clone starter translations"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: vivid-planet/comet-starter-lang
           token: ${{ secrets.GITHUB_TOKEN }}
           path: "admin/lang/starter-lang"
 
       - name: "Site: Clone starter translations"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: vivid-planet/comet-starter-lang
           token: ${{ secrets.GITHUB_TOKEN }}
           path: "site/lang/starter-lang"
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"

--- a/.github/workflows/publish-create-app.yml
+++ b/.github/workflows/publish-create-app.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - run: echo "${{ github.actor }}"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
       - run: |
@@ -26,7 +26,7 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - run: echo "${{ github.actor }}"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
@@ -29,7 +29,7 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"


### PR DESCRIPTION
Addresses the following warning: `The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-node@v3.`
