### PR TITLE
Prefer mapped types over column types when possible

### DIFF
--- a/api/src/documents/links/entities/link.entity.ts
+++ b/api/src/documents/links/entities/link.entity.ts
@@ -12,7 +12,7 @@ import { v4 } from "uuid";
 export class Link extends BaseEntity<Link, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";
 
-    @PrimaryKey({ columnType: "uuid" })
+    @PrimaryKey({ type: "uuid" })
     @Field(() => ID)
     id: string = v4();
 

--- a/api/src/documents/pages/entities/page.entity.ts
+++ b/api/src/documents/pages/entities/page.entity.ts
@@ -26,7 +26,7 @@ import { StageBlock } from "../blocks/stage.block";
 export class Page extends BaseEntity<Page, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";
 
-    @PrimaryKey({ columnType: "uuid" })
+    @PrimaryKey({ type: "uuid" })
     @Field(() => ID)
     id: string = v4();
 

--- a/api/src/page-tree/dto/page-tree-node-scope.ts
+++ b/api/src/page-tree/dto/page-tree-node-scope.ts
@@ -6,12 +6,12 @@ import { IsString } from "class-validator";
 @ObjectType("PageTreeNodeScope") // name must not be changed in the app
 @InputType("PageTreeNodeScopeInput") // name must not be changed in the app
 export class PageTreeNodeScope {
-    @Property({ columnType: "text" })
+    @Property({ type: "text" })
     @Field()
     @IsString()
     domain: string;
 
-    @Property({ columnType: "text" })
+    @Property({ type: "text" })
     @Field()
     @IsString()
     language: string;

--- a/api/src/redirects/dto/redirect-scope.ts
+++ b/api/src/redirects/dto/redirect-scope.ts
@@ -6,7 +6,7 @@ import { IsString } from "class-validator";
 @ObjectType("RedirectScope") // name must not be changed in the app
 @InputType("RedirectScopeInput") // name must not be changed in the app
 export class RedirectScope {
-    @Property({ columnType: "text" })
+    @Property({ type: "text" })
     @Field()
     @IsString()
     domain: string;


### PR DESCRIPTION
## Description

I've noticed that we're currently doing this inconsistently while debugging a bug in [getCrudSearchFieldsFromMetadata](https://github.com/vivid-planet/comet/blob/main/packages/api/cms-api/src/generator/utils/search-fields-from-metadata.ts#L6) together with @andrearutrecht. Since we're checking for `type` there, and not `columnType`, we should prefer `type` over `columnType` (We still need to fix the bug though).

## Further information

I've also looked at the MikroORM docs to find a best practice and found that they're using `type` in the [tutorial](https://mikro-orm.io/docs/guide/first-entity#first-entity), so I believe using `type` is preferred when it's possible.