### PR TITLE
Remove react-is dependency

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -18,7 +18,6 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-intl": "^6.0.0",
-                "react-is": "^17.0.2",
                 "redraft": "^0.10.0",
                 "styled-components": "^6.0.0",
                 "swiper": "^11.1.8",
@@ -12231,12 +12230,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/react-is": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "license": "MIT"
         },
         "node_modules/read-pkg": {
             "version": "3.0.0",

--- a/site/package.json
+++ b/site/package.json
@@ -31,7 +31,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intl": "^6.0.0",
-        "react-is": "^17.0.2",
         "redraft": "^0.10.0",
         "styled-components": "^6.0.0",
         "swiper": "^11.1.8",


### PR DESCRIPTION
Previously, styled-components required this dependency to be installed. For styled-components@6 this is no longer required, so we can remove the dependency as well.