### PR TITLE
Hotfix Admin Server

### DIFF
--- a/admin/server/server.js
+++ b/admin/server/server.js
@@ -8,7 +8,7 @@ const app = express();
 const port = process.env.APP_PORT ?? 3000;
 
 // Read index.html file
-let indexFile = fs.readFileSync("build/index.html", "utf8");
+let indexFile = fs.readFileSync("../build/index.html", "utf8");
 
 // Replace environment variables
 indexFile = indexFile.replace(/\$([A-Z_]+)/g, (match, p1) => {
@@ -42,7 +42,7 @@ app.get("/status/health", (req, res) => {
 });
 
 app.use(
-    express.static("./build", {
+    express.static("../build", {
         setHeaders: (res, path, stat) => {
             if (path.endsWith(".js")) {
                 // The js file is static and the index.html uses a parameter as cache buster
@@ -60,7 +60,8 @@ app.use(
 app.get("*", (req, res) => {
     // Don't cache the index.html at all to make sure applications updates are applied
     // implemented as suggested by https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#preventing_storing
-    res.send(indexFile, { headers: { "cache-control": "no-store" } });
+    res.setHeader("cache-control", "no-store");
+    res.send(indexFile);
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
- path of `index.html` is invalid (path is relative to `admin/server/server.js`)
- `res.send` signature is invalid (it tries to send the content as HTTP status code)

introduced by #367 