### PR TITLE
Add GitHub action to update DigitalOcean deployment

### DIFF
--- a/.github/workflows/update-digital-ocean-deployment.yml
+++ b/.github/workflows/update-digital-ocean-deployment.yml
@@ -2,7 +2,7 @@ name: Update DigitalOcean Deployment
 on:
   push:
     branches:
-      - test-do-action
+      - main
 jobs:
   update-deployment:
     name: Update DigitalOcean Deployment

--- a/.github/workflows/update-digital-ocean-deployment.yml
+++ b/.github/workflows/update-digital-ocean-deployment.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Needed to also fetch next branch
 
       - name: Install doctl package
         run: sudo snap install doctl

--- a/.github/workflows/update-digital-ocean-deployment.yml
+++ b/.github/workflows/update-digital-ocean-deployment.yml
@@ -1,0 +1,41 @@
+name: Update DigitalOcean Deployment
+on:
+  push:
+    branches:
+      - main
+jobs:
+  update-deployment:
+    name: Update DigitalOcean Deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Needed to also fetch next branch
+
+      - name: Install doctl package
+        run: sudo snap install doctl
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Authenticate doctl
+        run: doctl auth init -t ${{ secrets.DIGITALOCEAN_API_KEY }}
+
+      - name: Update DigitalOcean Deployment
+        run: |
+          doctl apps update ${{ vars.DIGITALOCEAN_IMGPROXY_APP_ID }} --spec .digitalocean/comet-starter-imgproxy.yaml
+          sed -i 's/dev\.comet\-dxp\.com/comet-starter-site-tyqqf.ondigitalocean.app/g' site-configs/main.ts
+
+          APP_ENV=dev npx -y @comet/cli inject-site-configs -i .digitalocean/comet-starter-cms.tpl.yaml -o .digitalocean/comet-starter-cms.yaml
+          doctl apps update ${{ vars.DIGITALOCEAN_CMS_APP_ID }} --spec .digitalocean/comet-starter-cms.yaml # Configuration-Changes
+          doctl apps create-deployment ${{ vars.DIGITALOCEAN_CMS_APP_ID }} # Code-Changes
+
+          APP_ENV=dev npx -y @comet/cli inject-site-configs -i .digitalocean/comet-starter-site-main.tpl.yaml -o .digitalocean/comet-starter-site-main.yaml
+          doctl apps update ${{ vars.DIGITALOCEAN_SITE_MAIN_APP_ID }} --spec .digitalocean/comet-starter-site-main.yaml # Configuration-Changes
+          doctl apps create-deployment ${{ vars.DIGITALOCEAN_SITE_MAIN_APP_ID }} # Code-Changes

--- a/.github/workflows/update-digital-ocean-deployment.yml
+++ b/.github/workflows/update-digital-ocean-deployment.yml
@@ -2,7 +2,7 @@ name: Update DigitalOcean Deployment
 on:
   push:
     branches:
-      - main
+      - test-do-action
 jobs:
   update-deployment:
     name: Update DigitalOcean Deployment
@@ -10,9 +10,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Install doctl package
-        run: sudo snap install doctl
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
@@ -22,18 +19,32 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Authenticate doctl
-        run: doctl auth init -t ${{ secrets.DIGITALOCEAN_API_KEY }}
-
-      - name: Update DigitalOcean Deployment
+      - name: Inject Site Configurations
         run: |
-          doctl apps update ${{ vars.DIGITALOCEAN_IMGPROXY_APP_ID }} --spec .digitalocean/comet-starter-imgproxy.yaml
           sed -i 's/dev\.comet\-dxp\.com/comet-starter-site-tyqqf.ondigitalocean.app/g' site-configs/main.ts
-
           APP_ENV=dev npx -y @comet/cli inject-site-configs -i .digitalocean/comet-starter-cms.tpl.yaml -o .digitalocean/comet-starter-cms.yaml
-          doctl apps update ${{ vars.DIGITALOCEAN_CMS_APP_ID }} --spec .digitalocean/comet-starter-cms.yaml # Configuration-Changes
-          doctl apps create-deployment ${{ vars.DIGITALOCEAN_CMS_APP_ID }} # Code-Changes
-
           APP_ENV=dev npx -y @comet/cli inject-site-configs -i .digitalocean/comet-starter-site-main.tpl.yaml -o .digitalocean/comet-starter-site-main.yaml
-          doctl apps update ${{ vars.DIGITALOCEAN_SITE_MAIN_APP_ID }} --spec .digitalocean/comet-starter-site-main.yaml # Configuration-Changes
-          doctl apps create-deployment ${{ vars.DIGITALOCEAN_SITE_MAIN_APP_ID }} # Code-Changes
+
+      - name: Update DigitalOcean comet-starter-imgproxy Deployment
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_API_KEY }}
+          print_deploy_logs: true
+          print_build_logs: true
+          app_spec_location: ".digitalocean/comet-starter-imgproxy.yaml"
+
+      - name: Update DigitalOcean comet-starter-cms Deployment
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_API_KEY }}
+          print_deploy_logs: true
+          print_build_logs: true
+          app_spec_location: ".digitalocean/comet-starter-cms.yaml"
+
+      - name: Update DigitalOcean comet-starter-site-main Deployment
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_API_KEY }}
+          print_deploy_logs: true
+          print_build_logs: true
+          app_spec_location: ".digitalocean/comet-starter-site-main.yaml"


### PR DESCRIPTION
- Add GitHub Action workflow to update DigitalOcean deployments on push to the `main` branch.
- Update and create deployments for `imgproxy`, `cms`, and `site-main` apps using `.digitalocean/deploy.sh` script.