### PR TITLE
Add content scope indicator to EditPage and EditLink

### DIFF
--- a/admin/src/documents/links/EditLink.tsx
+++ b/admin/src/documents/links/EditLink.tsx
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 import { Loading, MainContent, RouterPrompt, RouterTab, RouterTabs, Toolbar, ToolbarFillSpace, ToolbarItem, useStackApi } from "@comet/admin";
 import { ArrowLeft } from "@comet/admin-icons";
 import { AdminComponentRoot } from "@comet/blocks-admin";
-import { createUsePage, PageName } from "@comet/cms-admin";
+import { ContentScopeIndicator, createUsePage, PageName } from "@comet/cms-admin";
 import { IconButton } from "@mui/material";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import { useIntl } from "react-intl";
@@ -92,7 +92,7 @@ export const EditLink = ({ id }: Props) => {
                     }}
                 />
             )}
-            <Toolbar>
+            <Toolbar scopeIndicator={<ContentScopeIndicator />}>
                 <ToolbarItem>
                     <IconButton onClick={stackApi?.goBack} size="large">
                         <ArrowLeft />

--- a/admin/src/documents/pages/EditPage.tsx
+++ b/admin/src/documents/pages/EditPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Preview } from "@comet/admin-icons";
 import { AdminComponentRoot, AdminTabLabel } from "@comet/blocks-admin";
 import {
     BlockPreviewWithTabs,
+    ContentScopeIndicator,
     createUsePage,
     openSitePreviewWindow,
     PageName,
@@ -130,7 +131,7 @@ export const EditPage = ({ id }: Props) => {
                     }}
                 />
             )}
-            <Toolbar>
+            <Toolbar scopeIndicator={<ContentScopeIndicator />}>
                 <ToolbarItem>
                     <IconButton onClick={stackApi?.goBack} size="large">
                         <ArrowLeft />


### PR DESCRIPTION


## Description

Content Scope Indicator should show in EditPage and EditLink. We noticed this in a project.

## Video

Before:

https://github.com/user-attachments/assets/7ca525ce-4eb2-4eab-a59e-429a88430281

After:

https://github.com/user-attachments/assets/27110c4a-7a4c-424b-84b3-18372f0a613d


