### PR TITLE
Remove `mikro-orm:*` scripts

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -17,8 +17,6 @@
         "lint:eslint": "eslint --ext .ts,.tsx,.js,.jsx,.json,.md --max-warnings 0 src/ package.json",
         "lint:generated-files-not-modified": "npm run api-generator && git diff --exit-code HEAD --",
         "lint:tsc": "tsc --project ./tsconfig.lint.json",
-        "mikro-orm": "mikro-orm",
-        "mikro-orm:migration:generate": "mikro-orm migration:create",
         "start": "npm run prebuild && dotenv -e .env -e .env.local -e .env.secrets -e .env.site-configs -- nest start",
         "start:debug": "npm run prebuild && dotenv -e .env -e .env.local -e .env.secrets -e .env.site-configs -- nest start --debug --watch --preserveWatchOutput",
         "start:dev": "npm run prebuild && npm run db:migrate && npm run console createBlockIndexViews && dotenv -e .env -e .env.local -e .env.secrets -e .env.site-configs -- nest start --watch --preserveWatchOutput",


### PR DESCRIPTION
There's no benefit in having these scripts. Developers should use `npx mikro-orm` instead.
