### PR TITLE
Fix API build

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -20,6 +20,7 @@
             "@src/*": ["src/*"]
         }
     },
+    "include": ["src"],
     "exclude": ["dist"],
     "watchOptions": {
         "excludeDirectories": ["node_modules", "dist", "uploads"],


### PR DESCRIPTION
Moving the Jest config into a dedicated file (see https://github.com/vivid-planet/comet-starter/pull/402) caused TypeScript to create an additional `src/` folder in the `dist/` folder. Explicitly specifying `include` in the TSConfig resolves the issue.
