### PR TITLE
Outsource loadMessages function in own file

### DIFF
--- a/site/src/app/[domain]/[language]/layout.tsx
+++ b/site/src/app/[domain]/[language]/layout.tsx
@@ -1,16 +1,7 @@
 import { IntlProvider } from "@src/util/IntlProvider";
+import { loadMessages } from "@src/util/loadMessages";
 import { getSiteConfigForDomain } from "@src/util/siteConfig";
-import { readFile } from "fs/promises";
 import { PropsWithChildren } from "react";
-
-const messagesCache: Record<string, unknown> = {};
-export async function loadMessages(language: string) {
-    if (messagesCache[language]) return messagesCache[language];
-    const path = `./lang-compiled/${language}.json`;
-    const messages = JSON.parse(await readFile(path, "utf8"));
-    messagesCache[language] = messages;
-    return messages;
-}
 
 export default async function Page({ children, params: { domain, language } }: PropsWithChildren<{ params: { domain: string; language: string } }>) {
     const siteConfig = getSiteConfigForDomain(domain);

--- a/site/src/app/block-preview/[domain]/[language]/layout.tsx
+++ b/site/src/app/block-preview/[domain]/[language]/layout.tsx
@@ -1,5 +1,5 @@
-import { loadMessages } from "@src/app/[domain]/[language]/layout";
 import { IntlProvider } from "@src/util/IntlProvider";
+import { loadMessages } from "@src/util/loadMessages";
 import { PropsWithChildren } from "react";
 
 export default async function Page({ children, params: { language } }: PropsWithChildren<{ params: { language: string } }>) {

--- a/site/src/util/loadMessages.ts
+++ b/site/src/util/loadMessages.ts
@@ -1,0 +1,11 @@
+import { readFile } from "fs/promises";
+
+const messagesCache: Record<string, unknown> = {};
+
+export async function loadMessages(language: string) {
+    if (messagesCache[language]) return messagesCache[language];
+    const path = `./lang-compiled/${language}.json`;
+    const messages = JSON.parse(await readFile(path, "utf8"));
+    messagesCache[language] = messages;
+    return messages;
+}


### PR DESCRIPTION
## Description

If two different functions are exported in the `layout.tsx` file, the following error occurs when committing: 

<details>
    <summary>Screenshot of error message</summary>
<img width="1050" alt="Bildschirmfoto 2024-10-22 um 14 51 24" src="https://github.com/user-attachments/assets/176780e9-947e-47bd-91d4-6134d7e5cb60">
</details>

To fix the issue, the `loadMessages()` function is outsourced in a separate file. 

## Further information

https://stackoverflow.com/questions/76298505/my-next-js-app-isnt-building-and-returing-a-type-error-how-do-i-fix