### PR TITLE
Add RootLayout

### DIFF
--- a/site/src/app/[domain]/layout.tsx
+++ b/site/src/app/[domain]/layout.tsx
@@ -1,9 +1,6 @@
 import { SitePreviewProvider } from "@comet/cms-site";
-import { GlobalStyle } from "@src/layout/GlobalStyle";
-import { ResponsiveSpacingStyle } from "@src/util/ResponsiveSpacingStyle";
 import { getSiteConfigForDomain } from "@src/util/siteConfig";
 import { SiteConfigProvider } from "@src/util/SiteConfigProvider";
-import StyledComponentsRegistry from "@src/util/StyledComponentsRegistry";
 import type { Metadata } from "next";
 import { draftMode } from "next/headers";
 import { PropsWithChildren } from "react";
@@ -12,32 +9,26 @@ export const metadata: Metadata = {
     title: "Comet Starter",
 };
 
-export default async function RootLayout({ children, params: { domain } }: Readonly<PropsWithChildren<{ params: { domain: string } }>>) {
+export default async function SiteLayout({ children, params: { domain } }: Readonly<PropsWithChildren<{ params: { domain: string } }>>) {
     const siteConfig = await getSiteConfigForDomain(domain);
     const isDraftModeEnabled = draftMode().isEnabled;
 
     return (
-        <html>
-            <head />
-            <body>
-                {siteConfig.gtmId && (
-                    <noscript>
-                        <iframe
-                            src={`https://www.googletagmanager.com/ns.html?id=${siteConfig.gtmId}`}
-                            height="0"
-                            width="0"
-                            style={{ display: "none", visibility: "hidden" }}
-                        />
-                    </noscript>
-                )}
-                <StyledComponentsRegistry>
-                    <GlobalStyle />
-                    <ResponsiveSpacingStyle />
-                    <SiteConfigProvider siteConfig={siteConfig}>
-                        {isDraftModeEnabled ? <SitePreviewProvider>{children}</SitePreviewProvider> : children}
-                    </SiteConfigProvider>
-                </StyledComponentsRegistry>
-            </body>
-        </html>
+        <>
+            {siteConfig.gtmId && (
+                <noscript>
+                    <iframe
+                        src={`https://www.googletagmanager.com/ns.html?id=${siteConfig.gtmId}`}
+                        height="0"
+                        width="0"
+                        style={{ display: "none", visibility: "hidden" }}
+                    />
+                </noscript>
+            )}
+
+            <SiteConfigProvider siteConfig={siteConfig}>
+                {isDraftModeEnabled ? <SitePreviewProvider>{children}</SitePreviewProvider> : children}
+            </SiteConfigProvider>
+        </>
     );
 }

--- a/site/src/app/block-preview/[domain]/layout.tsx
+++ b/site/src/app/block-preview/[domain]/layout.tsx
@@ -1,23 +1,10 @@
 export const dynamic = "force-dynamic";
 
-import { GlobalStyle } from "@src/layout/GlobalStyle";
-import { ResponsiveSpacingStyle } from "@src/util/ResponsiveSpacingStyle";
 import { getSiteConfigForDomain } from "@src/util/siteConfig";
 import { SiteConfigProvider } from "@src/util/SiteConfigProvider";
-import StyledComponentsRegistry from "@src/util/StyledComponentsRegistry";
 import { PropsWithChildren } from "react";
 
 export default async function BlockPreviewLayout({ children, params: { domain } }: Readonly<PropsWithChildren<{ params: { domain: string } }>>) {
     const siteConfig = await getSiteConfigForDomain(domain);
-    return (
-        <html>
-            <body>
-                <StyledComponentsRegistry>
-                    <GlobalStyle />
-                    <ResponsiveSpacingStyle />
-                    <SiteConfigProvider siteConfig={siteConfig}>{children}</SiteConfigProvider>
-                </StyledComponentsRegistry>
-            </body>
-        </html>
-    );
+    return <SiteConfigProvider siteConfig={siteConfig}>{children}</SiteConfigProvider>;
 }

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import { GlobalStyle } from "@src/layout/GlobalStyle";
+import { ResponsiveSpacingStyle } from "@src/util/ResponsiveSpacingStyle";
+import StyledComponentsRegistry from "@src/util/StyledComponentsRegistry";
+
+export default async function RootLayout({
+    children,
+}: Readonly<{
+    children: React.ReactNode;
+}>) {
+    return (
+        <html>
+            <head />
+            <body>
+                <StyledComponentsRegistry>
+                    <GlobalStyle />
+                    <ResponsiveSpacingStyle />
+                    {children}
+                </StyledComponentsRegistry>
+            </body>
+        </html>
+    );
+}


### PR DESCRIPTION
## Description

Currently, there is a layout file for the site and a layout file for the block preview in the project. These partially contain the same content, for example both of them define the html and body tags.

To avoid code duplication, a root layout is created at the top-most level of the app directory. The existing layouts are used as child layouts of this one.

This way, fonts and similar resources no longer need to be imported twice.

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1167
