### PR TITLE
Import default font in RootLayout and use it in theme

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -7,6 +7,7 @@
             "name": "starter-site",
             "dependencies": {
                 "@comet/cms-site": "^7.5.0",
+                "@fontsource/roboto": "^5.1.0",
                 "@next/bundle-analyzer": "^14.0.0",
                 "@opentelemetry/api": "^1.9.0",
                 "@opentelemetry/auto-instrumentations-node": "^0.50.0",
@@ -2359,6 +2360,12 @@
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
+        },
+        "node_modules/@fontsource/roboto": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.1.0.tgz",
+            "integrity": "sha512-cFRRC1s6RqPygeZ8Uw/acwVHqih8Czjt6Q0MwoUoDe9U3m4dH1HmNDRBZyqlMSFwgNAUKgFImncKdmDHyKpwdg==",
+            "license": "Apache-2.0"
         },
         "node_modules/@formatjs/cli": {
             "version": "6.2.12",

--- a/site/package.json
+++ b/site/package.json
@@ -20,6 +20,7 @@
     },
     "dependencies": {
         "@comet/cms-site": "^7.5.0",
+        "@fontsource/roboto": "^5.1.0",
         "@next/bundle-analyzer": "^14.0.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.50.0",

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,3 +1,6 @@
+import "@fontsource/roboto";
+import "@fontsource/roboto/700.css";
+
 import { GlobalStyle } from "@src/layout/GlobalStyle";
 import { ResponsiveSpacingStyle } from "@src/util/ResponsiveSpacingStyle";
 import StyledComponentsRegistry from "@src/util/StyledComponentsRegistry";

--- a/site/src/theme.ts
+++ b/site/src/theme.ts
@@ -31,7 +31,7 @@ export const theme = {
             900: "#212121",
         },
     },
-    fontFamily: "Arial, sans-serif",
+    fontFamily: "Roboto",
     breakpoints: {
         xs: createBreakpoint(600),
         sm: createBreakpoint(900),

--- a/site/src/theme.ts
+++ b/site/src/theme.ts
@@ -31,7 +31,7 @@ export const theme = {
             900: "#212121",
         },
     },
-    fontFamily: "Roboto",
+    fontFamily: "Roboto, sans-serif",
     breakpoints: {
         xs: createBreakpoint(600),
         sm: createBreakpoint(900),


### PR DESCRIPTION
## Description

To ensure that the font is loaded in the block preview and in the site a default font is imported in the `RootLayout`. This also simplifies the use of other fonts in the project, as the default font only needs to be replaced:

To use a different font, the import in the `RootLayout`

```
import "@fontsource/roboto";
import "@fontsource/roboto/700.css";
```

and the specification of the `fontFamily` in the `theme` 

```
fontFamily: "Roboto, sans-serif",
```

must be adjusted.

<!--

The description should describe the change you're making.
It will be used as the commit message for the squashed commit once the PR gets merged.
Therefore, make sure to keep the description up-to-date as the PR changes.

PLEASE DESCRIBE WHY YOU'RE MAKING THE CHANGE, NOT WHAT YOU'RE CHANGING.
Reviewers see what you're changing when reviewing the code.
However, they might not understand your motives as to why you're making the change.

Your description should include:
-   The problem you're facing
-   Your solution to the problem
-   An example usage of your change

--->

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

-->

## Screenshots/screencasts

Font in Site

| Before   | After   |
| -------- | ------- |
| <img width="1823" alt="Bildschirmfoto 2024-10-24 um 08 09 00" src="https://github.com/user-attachments/assets/74a0e35c-44d7-4fb4-a813-f2a298fe20cb">     |   <img width="1824" alt="Bildschirmfoto 2024-10-24 um 08 08 06" src="https://github.com/user-attachments/assets/8c1496e7-127c-4a46-bef9-c4a67e04a03a"> |

Font in Block-Preview

| Before   | After   |
| -------- | ------- |
|   <img width="2259" alt="Bildschirmfoto 2024-10-24 um 08 08 49" src="https://github.com/user-attachments/assets/ef231765-33e2-4ea3-99a1-cb18398befb6">  |  <img width="2260" alt="Bildschirmfoto 2024-10-24 um 08 08 37" src="https://github.com/user-attachments/assets/8f719364-4e27-42ec-aebb-c0208aebbec6"> |



## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1163
