### PR TITLE
Use correct path for create-site-configs-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "starter",
     "private": true,
     "scripts": {
-        "create-site-configs-env": "npx @comet/cli inject-site-configs -f ../../../../../site-configs/site-configs.ts -i .env.site-configs.tpl -o .env.site-configs",
+        "create-site-configs-env": "npx @comet/cli inject-site-configs -f site-configs/site-configs.ts -i .env.site-configs.tpl -o .env.site-configs",
         "dev": "npm run create-site-configs-env && dev-pm start",
         "copy-schema-files": "node copy-schema-files.js",
         "lint": "run-p lint:*",


### PR DESCRIPTION
This is a bugfix.

In https://github.com/vivid-planet/comet-starter/pull/401 the path for the digitalocean deployment had to be prefixed, but it's not necessary to prefix for the local development.