### PR TITLE
Add hook for NEXT_PUBLIC

### DIFF
--- a/site/src/app/block-preview/[domain]/[language]/footer/page.tsx
+++ b/site/src/app/block-preview/[domain]/[language]/footer/page.tsx
@@ -3,14 +3,14 @@
 import { BlockPreviewProvider, IFrameBridgeProvider, useBlockPreviewFetch, useIFrameBridge } from "@comet/cms-site";
 import { FooterContentBlockData } from "@src/blocks.generated";
 import { FooterContentBlock } from "@src/documents/pages/blocks/FooterContentBlock";
-import { graphQLApiUrl } from "@src/util/graphQLClient";
+import { useNextPublic } from "@src/util/NextPublicProvider";
 import { recursivelyLoadBlockData } from "@src/util/recursivelyLoadBlockData";
 import { FunctionComponent, useEffect, useState } from "react";
 
 const PreviewPage: FunctionComponent = () => {
     const iFrameBridge = useIFrameBridge();
 
-    const { fetch, graphQLFetch } = useBlockPreviewFetch(graphQLApiUrl);
+    const { fetch, graphQLFetch } = useBlockPreviewFetch(`${useNextPublic("API_URL")}/graphql`);
 
     const [blockData, setBlockData] = useState<FooterContentBlockData>();
     useEffect(() => {

--- a/site/src/app/block-preview/[domain]/[language]/page/page.tsx
+++ b/site/src/app/block-preview/[domain]/[language]/page/page.tsx
@@ -4,14 +4,14 @@ import { useBlockPreviewFetch, useIFrameBridge } from "@comet/cms-site";
 import { PageContentBlockData } from "@src/blocks.generated";
 import { PageContentBlock } from "@src/documents/pages/blocks/PageContentBlock";
 import { withBlockPreview } from "@src/util/blockPreview";
-import { graphQLApiUrl } from "@src/util/graphQLClient";
+import { useNextPublic } from "@src/util/NextPublicProvider";
 import { recursivelyLoadBlockData } from "@src/util/recursivelyLoadBlockData";
 import { useEffect, useState } from "react";
 
 export default withBlockPreview(() => {
     const iFrameBridge = useIFrameBridge();
 
-    const { fetch, graphQLFetch } = useBlockPreviewFetch(graphQLApiUrl);
+    const { fetch, graphQLFetch } = useBlockPreviewFetch(`${useNextPublic("API_URL")}/graphql`);
 
     const [blockData, setBlockData] = useState<PageContentBlockData>();
     useEffect(() => {

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -2,6 +2,8 @@ import "@fontsource/roboto";
 import "@fontsource/roboto/700.css";
 
 import { GlobalStyle } from "@src/layout/GlobalStyle";
+import { extractNextPublicEnvs } from "@src/util/nextPublic";
+import { NextPublicProvider } from "@src/util/NextPublicProvider";
 import { ResponsiveSpacingStyle } from "@src/util/ResponsiveSpacingStyle";
 import StyledComponentsRegistry from "@src/util/StyledComponentsRegistry";
 
@@ -14,11 +16,13 @@ export default async function RootLayout({
         <html>
             <head />
             <body>
-                <StyledComponentsRegistry>
-                    <GlobalStyle />
-                    <ResponsiveSpacingStyle />
-                    {children}
-                </StyledComponentsRegistry>
+                <NextPublicProvider envs={extractNextPublicEnvs(process.env)}>
+                    <StyledComponentsRegistry>
+                        <GlobalStyle />
+                        <ResponsiveSpacingStyle />
+                        {children}
+                    </StyledComponentsRegistry>
+                </NextPublicProvider>
             </body>
         </html>
     );

--- a/site/src/util/NextPublicProvider.tsx
+++ b/site/src/util/NextPublicProvider.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { createContext, PropsWithChildren, useContext } from "react";
+
+export type NextPublicEnvs = Record<string, string>;
+
+const NextPublicContext = createContext<NextPublicEnvs>({});
+
+export function NextPublicProvider({ children, envs }: PropsWithChildren<{ envs: NextPublicEnvs }>) {
+    return <NextPublicContext.Provider value={envs}>{children}</NextPublicContext.Provider>;
+}
+
+export function useNextPublic(key: string) {
+    return useContext(NextPublicContext)[key];
+}

--- a/site/src/util/graphQLClient.ts
+++ b/site/src/util/graphQLClient.ts
@@ -5,19 +5,18 @@ import {
     SitePreviewData,
 } from "@comet/cms-site";
 
-const isServerSide = typeof window === "undefined";
-export const graphQLApiUrl = `${isServerSide ? process.env.API_URL_INTERNAL : process.env.NEXT_PUBLIC_API_URL}/graphql`;
 export function createGraphQLFetch(previewData?: SitePreviewData) {
+    if (typeof window !== "undefined") {
+        throw new Error("createGraphQLFetch: cannot use on client side.");
+    }
+
     const headers: HeadersInit = {
+        authorization: `Basic ${Buffer.from(`system-user:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
         "x-relative-dam-urls": "1",
     };
 
-    if (isServerSide) {
-        headers.authorization = `Basic ${Buffer.from(`system-user:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`;
-    }
-
     return createGraphQLFetchLibrary(
         createFetchWithDefaults(createFetchWithPreviewHeaders(fetch, previewData), { next: { revalidate: 15 * 60 }, headers }),
-        graphQLApiUrl,
+        `${process.env.API_URL_INTERNAL}/graphql`,
     );
 }

--- a/site/src/util/nextPublic.ts
+++ b/site/src/util/nextPublic.ts
@@ -1,0 +1,9 @@
+import type { NextPublicEnvs } from "./NextPublicProvider";
+
+export function extractNextPublicEnvs(envs: typeof process.env): NextPublicEnvs {
+    return Object.fromEntries(
+        Object.entries(envs)
+            .filter(([key]) => key.startsWith("NEXT_PUBLIC_"))
+            .map(([key, val]) => [key.replace("NEXT_PUBLIC_", ""), val || ""]),
+    );
+}


### PR DESCRIPTION
## Description

Some deployment processes (like our's) don't correctly support Next.js proposed way of client side used environment variables as the required variables are not available during next build.

This PR introduces a Provider and a hook to ease access to NEXT_PUBLIC-envs. Moreover, it prevents misusing the site-configs for these kind of general envs.

There is already a first use case implemented in this PR. Blocks with a separate loader need the api url on the client side when called via block-preview.

## Further information

- This acts as a lightweight alternative to https://github.com/expatfile/next-runtime-env
- It's not possible to move the provider to cms-site as code splitting doesn't work correctly anymore.