### PR TITLE
chore: renovate config change rangeStrategy to bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,5 +55,6 @@
             "matchPackagePatterns": ["^open-telemetry/*"],
             "groupName": "OpenTelemetry"
         }
-    ]
+    ],
+    "rangeStrategy": "bump"
 }


### PR DESCRIPTION
this pull requests changes renovate behaviour, that the package json gets bumped as well to the latest version configured

More information on rangeStrategie can be found here: https://docs.renovatebot.com/configuration-options/#rangestrategy