### PR TITLE
Remove apollo.config.js

### DIFF
--- a/site/apollo.config.js
+++ b/site/apollo.config.js
@@ -1,9 +1,0 @@
-// eslint-disable-next-line no-undef
-module.exports = {
-    client: {
-        service: {
-            name: "api",
-            localSchemaFile: "./schema.graphql",
-        },
-    },
-};


### PR DESCRIPTION
This was initially added to enable support for GraphQL syntax highlighting in VS Code using the Apollo extension. Since then, the GraphQL Foundation released [official extensions](https://marketplace.visualstudio.com/publishers/GraphQL), which work without a config file. Those extensions should be used instead.
