### PR TITLE
chore: add new auto_assign_dependency_updates file with dedicated dependency update reviewers

### DIFF
--- a/.github/auto_assign_dependency_updates.yml
+++ b/.github/auto_assign_dependency_updates.yml
@@ -3,10 +3,7 @@ addAssignees: author
 addReviewers: true
 
 reviewers:
-  - dkarnutsch
-  - fraxachun
   - johnnyomair
-  - nsams
   - thomasdax98
   - manuelblum
 

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -16,10 +16,10 @@ jobs:
         if: github.actor == 'renovate[bot]'
         uses: kentaro-m/auto-assign-action@v2.0.0
         with:
-          config: ".github/auto_assign_dependency_updates.yml"
+          configuration-path: ".github/auto_assign_dependency_updates.yml"
 
       - name: Assign default reviewers
         if: github.actor != 'renovate[bot]'
         uses: kentaro-m/auto-assign-action@v2.0.0
         with:
-          config: ".github/auto_assign.yml"
+          configuration-path: ".github/auto_assign.yml"

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -16,16 +16,10 @@ jobs:
         if: github.actor == 'renovate[bot]'
         uses: kentaro-m/auto-assign-action@v2.0.0
         with:
-          config: ".github/auto_assign.yml"
-          reviewGroup: "dependencyUpdates"
-          addReviewers: true
-          addAssignees: false
+          config: ".github/auto_assign_dependency_updates.yml"
 
       - name: Assign default reviewers
         if: github.actor != 'renovate[bot]'
         uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           config: ".github/auto_assign.yml"
-          reviewGroup: "default"
-          addReviewers: true
-          addAssignees: false


### PR DESCRIPTION
chore: add new auto_assign_dependency_updates file with dedicated dependency update reviewers

before:
![Screenshot 2024-11-12 at 08 21 49](https://github.com/user-attachments/assets/352364ee-c6c3-4ba4-94d4-891c1eb8342a)

after:
<img width="852" alt="Screenshot 2024-11-12 at 08 21 41" src="https://github.com/user-attachments/assets/c05057c7-3cfd-45f0-ab37-8d33adb995a7">
