### PR TITLE
fix: flaky admin deployment

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -94,5 +94,9 @@
         "typescript": "~5.1.0",
         "vite": "^5.4.11",
         "vite-plugin-html": "^3.2.2"
-    }
+    },
+    "cacheDirectories": [
+        "node_modules",
+        "server/node_modules"
+    ]
 }


### PR DESCRIPTION
There is a flakiness in the deployment to Digital Ocean because there is an additional npm package inside the admin directory, containing `node_modules` (`admin/server/node_modules`). 

After following some Documentation, and in this [Documentation](https://devcenter.heroku.com/articles/nodejs-support#custom-caching) it's stated that one can specify **cacheDirectories** on top level package json. Digital Ocean should use this under the hood.

**Current Flaky Problem:**
<img width="2560" alt="Screenshot 2024-11-12 at 09 11 49" src="https://github.com/user-attachments/assets/aed2b7a2-0761-411b-b940-f00578886498">
https://github.com/vivid-planet/comet-starter/actions/runs/11792193951/job/32845438332