### PR TITLE
Use repository secrets for digital ocean deployment

### DIFF
--- a/.digitalocean/comet-starter-cms.tpl.yaml
+++ b/.digitalocean/comet-starter-cms.tpl.yaml
@@ -44,7 +44,7 @@ services:
       - key: POSTGRESQL_PASSWORD
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:VJWKcWvicy4ClCPNzpPOSwiZB0p8/gZq:SZK9hwGdXBqcCEApIdFWuSLWS//rvY/VEfyJ2WWwM/agjP+BLUOiew==] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${POSTGRESQL_PASSWORD}
       - key: POSTGRESQL_USER
         scope: RUN_AND_BUILD_TIME
         value: starter
@@ -60,18 +60,18 @@ services:
       - key: IMGPROXY_SALT
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:DpbiOlcKj5C5taV+27VGP0Wc2GFFu0Cu:I8RNxsSOqaGk12doCtjeIT9hUNWTM6rAr7kMX6X+JlE4VyYH5kd1XFZ9SozGmADqFKEkI//BIJQ00XAq6dkXr6amsH7AtVJSxkl4WjBBs24sW/jnSIjebEYDq4n9oQbptdhrQcNwTYaAy/VZm1KzgzxdXaQHDsLmbtYWXLKUue/VldiCajnRExZjiTdk/x8Y] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${IMGPROXY_SALT}
       - key: IMGPROXY_URL
         scope: RUN_AND_BUILD_TIME
         value: https://comet-starter-imgproxy-ovgzu.ondigitalocean.app
       - key: IMGPROXY_KEY
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:wD77N9Aop33RXd8qv/pUCyIyItqY877u:DeExUMZXlI96dabfE09kuc/Kj54FZmVrjuTb2VMLajK1B+fxuNIHecelUdFX1wo1lrYm+jRFBotC8nWh4uhEYfC4KVS6QdjeKIXAxhuZ7cGI848/VAzkWKoEgYoSUYTXNTbpETptNFWQ1XFzJxDKZiYFaW8LmknvxUixuaxULsobxjFhH/S+fTlHt6j9DN9K] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${IMGPROXY_KEY}
       - key: DAM_SECRET
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:cN8JQAPIBnJqXpO8RGBqx9tvzArnSMFz:tQ2EW+BE5XWg2rPUvXqCjbXKNxIYLRGLdsAKk+CVhaDRWhc=] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${DAM_SECRET}
       - key: BLOB_STORAGE_DRIVER
         scope: RUN_AND_BUILD_TIME
         value: s3
@@ -90,11 +90,11 @@ services:
       - key: S3_ACCESS_KEY_ID
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:MoPtts0J/3qbPVcLpNbJDQncPsvQBWmG:sseL7FpcEps7IV5v/uqBctUwp+tSMBAzJl3XkZjMCLZ69PUt] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${S3_ACCESS_KEY_ID}
       - key: S3_SECRET_ACCESS_KEY
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:GNjlve0WqXUtZr2TVaxvI9UTcv6a0Mta:zK4fpoWTpwDHO6MfYEWLoOsw3Kq3W3N9FvGAIuHRc1I6FF6zeZOULOIxzOXgLJPb6xIIiUKB8dAOu7Y=] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${S3_SECRET_ACCESS_KEY}
       - key: POSTGRESQL_CA_CERT
         scope: RUN_AND_BUILD_TIME
         value: |-
@@ -135,7 +135,7 @@ services:
       - key: BASIC_AUTH_SYSTEM_USER_PASSWORD
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:RRBCV3yOi07TjXxGcad36RGJAJ2DnHbw:mmzqyMwl9gtfoiNigjj/0GrZTduEp6LtgJKV/5a3geMwKSk=] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${API_BASIC_AUTH_SYSTEM_USER_PASSWORD}
       - key: IDP_CLIENT_ID
         scope: RUN_AND_BUILD_TIME
         value: 59e44de5-0431-4413-b50b-7e52740a6d7b
@@ -204,14 +204,14 @@ services:
       - key: OAUTH2_PROXY_CLIENT_SECRET
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:uQi0YzdSCPn4w2obTTkdFOiUmYC0onNR:NEwKBNspvye4T0NkL6QpCP5PiTduvpyfnF/JjvKbX8Aec0s=] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${OAUTH2_PROXY_CLIENT_SECRET}
       - key: OAUTH2_PROXY_CLIENT_ID
         scope: RUN_AND_BUILD_TIME
         value: 59e44de5-0431-4413-b50b-7e52740a6d7b
       - key: OAUTH2_PROXY_COOKIE_SECRET
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:nG0XBGrISwLqRYdFFELwYeszfQ0vMCjC:XBISzF+YWffV1LA25rTvp4v6iLhjVL4a3VGkd2v7Iiw=] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${OAUTH2_PROXY_COOKIE_SECRET}
       - key: OAUTH2_PROXY_PROVIDER
         scope: RUN_AND_BUILD_TIME
         value: oidc
@@ -236,7 +236,7 @@ services:
       - key: SITE_PREVIEW_SECRET
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:A4X6zGCPT5FxJeeVfJN6/+qMheIJiRR4:rVkXdx0O7CoYtL9DgiFI2JNtntbOYIvgP+wR1B9un+s=] # This secret got created and encrypted in Digital Ocean Web Application
+        value: ${SITE_PREVIEW_SECRET}
     http_port: 4180
     image:
       registry: dkarnutsch

--- a/.digitalocean/comet-starter-imgproxy.yaml
+++ b/.digitalocean/comet-starter-imgproxy.yaml
@@ -17,11 +17,11 @@ services:
       - key: IMGPROXY_KEY
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:caLHr/u1NkMWvW8NG5nn0+JvpBW+NMNu:yhmQi6RpvAt58666wyk3IzIMFg7ALTeIhruXpPFabcQgSkmAaBXzj08oAYuhv6u0tnWabUIHDkvzyY0CnoYpHD3vE1R5tWLUQwOoEgzGKHqiO7f5zdeuTzFUxG7ctCFfsXedzL2e4R7+u3FmLox0woPk0DhbiYiA8+qSNnVEKWMXJTkAkfQkwdtovgskqdz5]
+        value: ${IMGPROXY_KEY}
       - key: IMGPROXY_SALT
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:yCE1f0mZPV+uFFs96/SmFsbvWXH3pfDn:1dt+Waq2vALvR7qXaC3Lh2VONtDjgmBzSuPyn+6kpk3DN9xzmbSPhV3G1pCZ+NRA16TOL3jhfiIgWD4QbCAs5y2JM2EOcptDQKpuQ6YYGvB9Gb2dBgrJS7WG5pKqSIuI3g+YKKa/ns5HWzH/CdIsieVdvmlb4PFasdhdCIMOHCIhwNONChz0yIO7XsV8vLJl]
+        value: ${IMGPROXY_SALT}
       - key: IMGPROXY_USE_S3
         scope: RUN_AND_BUILD_TIME
         value: "true"
@@ -34,11 +34,11 @@ services:
       - key: AWS_ACCESS_KEY_ID
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:utFAK7Ej0e07tb6cQhWCCLlRUSKJy6DU:rGoIItdercf5JSs2oSEanA11liimnDjdLxwmhcBjO9UCeHaM]
+        value: ${S3_ACCESS_KEY_ID}
       - key: AWS_SECRET_ACCESS_KEY
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:xupjwXwlpZv8VeQyLx9nKJTrw1BipI3a:Lkws9OWy+b5a20BNHCHiFv8H2M99aYNirhY+eGBZsCoUkLvCYoJvKDaVpHLz7N+CCC3Hfgycd4Ix008=]
+        value: ${S3_SECRET_ACCESS_KEY}
     http_port: 8080
     image:
       registry: darthsim

--- a/.digitalocean/comet-starter-site-main.tpl.yaml
+++ b/.digitalocean/comet-starter-site-main.tpl.yaml
@@ -38,14 +38,14 @@ services:
       - key: SITE_PREVIEW_SECRET
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:/Nf0VXO5XP5SJY9Y/JAFyZttB4Z1B6po:xL4pWQaF02cU4y1QCahqXdvD94A+QOJxXVVGDea4TYFVPQ==]
+        value: ${SITE_PREVIEW_SECRET}
       - key: PUBLIC_SITE_CONFIGS
         scope: RUN_AND_BUILD_TIME
         value: "{{ site://configs/public/dev }}"
       - key: API_BASIC_AUTH_SYSTEM_USER_PASSWORD
         scope: RUN_AND_BUILD_TIME
         type: SECRET
-        value: EV[1:qkU44a+IP3BfIT4YvfGdrOj505b+mdu2:aD7wKJCkMvTng/HGtOjuXg2QjP2KGUn8FHghsVmZpptr4JA=]
+        value: ${API_BASIC_AUTH_SYSTEM_USER_PASSWORD}
     github:
       branch: main
       deploy_on_push: false


### PR DESCRIPTION
As recommended in https://github.com/digitalocean/app_action?tab=readme-ov-file#deploy-an-app-with-a-referenced-secret. Now it is not required to first set the secret via Digital Ocean Portal.