### PR TITLE
Admin: Workaround for missing server node_modules on DigitalOcean

### DIFF
--- a/.digitalocean/comet-starter-cms.tpl.yaml
+++ b/.digitalocean/comet-starter-cms.tpl.yaml
@@ -279,5 +279,5 @@ services:
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb
     name: admin
-    run_command: npm run serve
+    run_command: cd server && npm i && node server.js # Workaround for missing node_modules in cache (only parent node_mdoules are cached)
     source_dir: admin

--- a/admin/package.json
+++ b/admin/package.json
@@ -94,9 +94,5 @@
         "typescript": "~5.1.0",
         "vite": "^5.4.11",
         "vite-plugin-html": "^3.2.2"
-    },
-    "cacheDirectories": [
-        "node_modules",
-        "server/node_modules"
-    ]
+    }
 }


### PR DESCRIPTION
As https://docs.digitalocean.com/products/app-platform/reference/buildpacks/nodejs/#caching does not indicate any option to specify multiple cache_dirs I've decided it is not worth the time to further investigate this
