### PR TITLE
chore: add labels for renovate pull requests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,10 @@
         {
             "groupName": "OpenTelemetry",
             "matchPackageNames": ["/^open-telemetry/*/"]
+        },
+        {
+            "matchUpdateTypes": ["major"],
+            "labels": ["major"]
         }
     ],
     "rangeStrategy": "bump",

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
         {
             "groupName": "comet",
             "prPriority": 6,
-            "matchPackageNames": ["/@comet/*/"]
+            "matchPackageNames": ["/@comet/*/"],
+            "labels": ["comet", "dependencies"]
         },
         {
             "groupName": "types",
@@ -61,5 +62,6 @@
             "matchPackageNames": ["/^open-telemetry/*/"]
         }
     ],
-    "rangeStrategy": "bump"
+    "rangeStrategy": "bump",
+    "labels": ["dependencies"]
 }


### PR DESCRIPTION
Automatically adds labels to pull requests when renovate opens dependency bumps:

**Dependency Pull Requests:**
<img width="1371" alt="Screenshot 2024-11-14 at 07 42 47" src="https://github.com/user-attachments/assets/f28e2070-2876-4363-bcb0-7e49f7ea2068">

**Comet Dependency Pull Requests**
<img width="1371" alt="Screenshot 2024-11-14 at 07 45 15" src="https://github.com/user-attachments/assets/b13c2423-7c74-41c7-8233-6a1134e74cf3">

**Major Updates of dependencies**
mark major updates of dependencies with a special label to make people aware that there can break something.
<img width="1421" alt="Screenshot 2024-11-14 at 08 04 17" src="https://github.com/user-attachments/assets/201d117c-48f3-478c-94c2-576e341c1aa2">
