### PR TITLE
Remove unused `@nestjs/config` module

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16,7 +16,6 @@
                 "@mikro-orm/postgresql": "^5.9.8",
                 "@nestjs/apollo": "^10.2.1",
                 "@nestjs/common": "^9.4.3",
-                "@nestjs/config": "^2.3.4",
                 "@nestjs/core": "^9.4.3",
                 "@nestjs/graphql": "^10.2.1",
                 "@nestjs/passport": "^9.0.3",
@@ -4861,44 +4860,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
             "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
             "license": "0BSD"
-        },
-        "node_modules/@nestjs/config": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-2.3.4.tgz",
-            "integrity": "sha512-IGdSF+0F9MJO6dCRTEahdxPz4iVijjtolcFBxnY+2QYM3bXYQvAgzskGZi+WkAFJN/VzR3TEp60gN5sI74GxPA==",
-            "license": "MIT",
-            "dependencies": {
-                "dotenv": "16.1.4",
-                "dotenv-expand": "10.0.0",
-                "lodash": "4.17.21",
-                "uuid": "9.0.0"
-            },
-            "peerDependencies": {
-                "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
-                "reflect-metadata": "^0.1.13",
-                "rxjs": "^6.0.0 || ^7.2.0"
-            }
-        },
-        "node_modules/@nestjs/config/node_modules/dotenv": {
-            "version": "16.1.4",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
-            "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/motdotla/dotenv?sponsor=1"
-            }
-        },
-        "node_modules/@nestjs/config/node_modules/uuid": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
         },
         "node_modules/@nestjs/core": {
             "version": "9.4.3",
@@ -13252,6 +13213,7 @@
             "version": "10.0.0",
             "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
             "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"

--- a/api/package.json
+++ b/api/package.json
@@ -37,7 +37,6 @@
         "@mikro-orm/postgresql": "^5.9.8",
         "@nestjs/apollo": "^10.2.1",
         "@nestjs/common": "^9.4.3",
-        "@nestjs/config": "^2.3.4",
         "@nestjs/core": "^9.4.3",
         "@nestjs/graphql": "^10.2.1",
         "@nestjs/passport": "^9.0.3",

--- a/api/src/db/fixtures/fixtures.module.ts
+++ b/api/src/db/fixtures/fixtures.module.ts
@@ -1,11 +1,10 @@
 import { DependenciesModule } from "@comet/cms-api";
 import { Module } from "@nestjs/common";
-import { ConfigModule } from "@nestjs/config";
 import { FixturesConsole } from "@src/db/fixtures/fixtures.console";
 import { ConsoleModule } from "nestjs-console";
 
 @Module({
-    imports: [ConfigModule, ConsoleModule, DependenciesModule],
+    imports: [ConsoleModule, DependenciesModule],
     providers: [FixturesConsole],
     exports: [],
 })


### PR DESCRIPTION
We've changed our approach to configuration with Comet v4, but never removed this module.