### PR TITLE
Refactor DigitalOcean deployment workflow

### DIFF
--- a/.github/workflows/update-digital-ocean-deployment.yml
+++ b/.github/workflows/update-digital-ocean-deployment.yml
@@ -11,6 +11,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install doctl package
+        run: sudo snap install doctl
+
       - name: Setup Node.js 22.x
         uses: actions/setup-node@v4
         with:
@@ -19,32 +22,18 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Inject Site Configurations
+      - name: Authenticate doctl
+        run: doctl auth init -t ${{ secrets.DIGITALOCEAN_API_KEY }}
+
+      - name: Update DigitalOcean Deployment
         run: |
+          doctl apps update ${{ vars.DIGITALOCEAN_IMGPROXY_APP_ID }} --spec .digitalocean/comet-starter-imgproxy.yaml
           sed -i 's/dev\.comet\-dxp\.com/comet-starter-site-tyqqf.ondigitalocean.app/g' site-configs/main.ts
+
           APP_ENV=dev npx -y @comet/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/comet-starter-cms.tpl.yaml -o .digitalocean/comet-starter-cms.yaml
+          doctl apps update ${{ vars.DIGITALOCEAN_CMS_APP_ID }} --spec .digitalocean/comet-starter-cms.yaml # Configuration-Changes
+          doctl apps create-deployment ${{ vars.DIGITALOCEAN_CMS_APP_ID }} # Code-Changes
+
           APP_ENV=dev npx -y @comet/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/comet-starter-site-main.tpl.yaml -o .digitalocean/comet-starter-site-main.yaml
-
-      - name: Update DigitalOcean comet-starter-imgproxy Deployment
-        uses: digitalocean/app_action/deploy@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_API_KEY }}
-          print_deploy_logs: true
-          print_build_logs: true
-          app_spec_location: ".digitalocean/comet-starter-imgproxy.yaml"
-
-      - name: Update DigitalOcean comet-starter-cms Deployment
-        uses: digitalocean/app_action/deploy@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_API_KEY }}
-          print_deploy_logs: true
-          print_build_logs: true
-          app_spec_location: ".digitalocean/comet-starter-cms.yaml"
-
-      - name: Update DigitalOcean comet-starter-site-main Deployment
-        uses: digitalocean/app_action/deploy@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_API_KEY }}
-          print_deploy_logs: true
-          print_build_logs: true
-          app_spec_location: ".digitalocean/comet-starter-site-main.yaml"
+          doctl apps update ${{ vars.DIGITALOCEAN_SITE_MAIN_APP_ID }} --spec .digitalocean/comet-starter-site-main.yaml # Configuration-Changes
+          doctl apps create-deployment ${{ vars.DIGITALOCEAN_SITE_MAIN_APP_ID }} # Code-Changes


### PR DESCRIPTION
Refactor: https://github.com/vivid-planet/comet-starter/pull/398

- Remove DigitalOcean GitHub actions due to deployment issues
- Use `doctl` package for deployment
- Use deployment script from: https://github.com/vivid-planet/comet-starter/blob/main/.digitalocean/deploy.sh
