### PR TITLE
Exclude Comet from Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,6 @@
     "extends": ["config:recommended", ":semanticCommitsDisabled"],
     "packageRules": [
         {
-            "groupName": "comet",
-            "prPriority": 6,
-            "matchPackageNames": ["/@comet/*/"],
-            "labels": ["comet", "dependencies"]
-        },
-        {
             "groupName": "linters",
             "matchPackageNames": ["/^eslint/", "/^prettier/"]
         },


### PR DESCRIPTION
Minor Comet updates can cause changes to schema.gql or block-meta.json. As long as we don't have a lint for that, I don't want to have PRs for Comet that get merged without starting the API once.
