### PR TITLE
Remove package manager pinning from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2"
     },
-    "packageManager": "npm@10.9.1",
     "engines": {
         "node": "22"
     }


### PR DESCRIPTION
This was unintentionally introduced with https://github.com/vivid-planet/comet-starter/pull/418/ and updated through renovate.
