### PR TITLE
Site Cache Handler: set fallback cache only when Redis is not ready

### DIFF
--- a/site/cache-handler.ts
+++ b/site/cache-handler.ts
@@ -92,7 +92,7 @@ export default class CacheHandler {
             const responseBody = parseBodyForGqlError(value.data.body);
             if (responseBody?.errors) {
                 // Must not cache GraphQL errors
-                console.error("CacheHandler.set GraphQL Error: ", responseBody.error);
+                console.error("CacheHandler.set GraphQL Error: ", responseBody.errors);
                 return;
             }
         }

--- a/site/cache-handler.ts
+++ b/site/cache-handler.ts
@@ -108,6 +108,7 @@ export default class CacheHandler {
             } catch (e) {
                 console.error("CacheHandler.set error", e);
             }
+            return;
         }
         fallbackCache.set(key, value, { size: stringData.length });
     }


### PR DESCRIPTION
## Description

Currently, we store everything in the fallback cache.