### PR TITLE
Don't fail GraphQL Codegen if there are no documents

### DIFF
--- a/admin/codegen.ts
+++ b/admin/codegen.ts
@@ -53,6 +53,7 @@ const config: CodegenConfig = {
             ],
         },
     },
+    ignoreNoDocuments: true,
 };
 
 export default config;

--- a/site/codegen.ts
+++ b/site/codegen.ts
@@ -38,6 +38,7 @@ const config: CodegenConfig = {
             config: pluginConfig,
         },
     },
+    ignoreNoDocuments: true,
 };
 
 export default config;


### PR DESCRIPTION
This happened in one of our projects: GraphQL Codegen fails with the non-obvious error `A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference.`. To fix this, we enable the `ignoreNoDocuments` option.