### PR TITLE
Fix lint workflow not failing on error

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,13 +58,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: npm ci & npm --prefix api ci & npm --prefix admin ci & npm --prefix site ci & wait
+        run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix site ci
 
       - name: Copy schema files
         run: npm run copy-schema-files
 
       - name: Lint
-        run: npm run lint:root & npm --prefix api run lint:ci & npm --prefix admin run lint:ci & npm --prefix site run lint:ci & wait
+        run: npm run lint:root && npm --prefix api run lint:ci && npm --prefix admin run lint:ci && npm --prefix site run lint:ci
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
The install and lint commands of the microservices were run in parallel using `&` in combination with `wait`. However, doing so caused the step to not fail if one of the commands failed. We therefore remove the parallelization and use the good old `&&`.