### PR TITLE
Fix DigitalOcean API build

### DIFF
--- a/api/knip.json
+++ b/api/knip.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://unpkg.com/knip@5/schema.json",
-    "entry": ["./src/main.ts", "./src/console.ts", "./src/repl.ts", "./src/db/ormconfig.cli.ts"],
+    "entry": ["./src/main.ts", "./src/console.ts", "./src/repl.ts", "./src/db/ormconfig.cli.ts", "./src/site-configs.d.ts"],
     "project": ["./src/**/*.{ts,tsx}"],
     "ignore": ["./src/db/migrations/**/*.ts"],
     "ignoreDependencies": ["@mikro-orm/cli", "jest-junit"],

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -39,6 +39,7 @@
                 "uuid": "^8.3.2"
             },
             "devDependencies": {
+                "@comet/cli": "^7.10.0",
                 "@comet/eslint-config": "^7.10.0",
                 "@cspell/eslint-plugin": "^8.16.1",
                 "@jest/types": "^29.6.3",
@@ -2588,6 +2589,23 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/@comet/cli": {
+            "version": "7.10.0",
+            "resolved": "https://registry.npmjs.org/@comet/cli/-/cli-7.10.0.tgz",
+            "integrity": "sha512-P9LDFrUN/U5vH2/3L3Z9QB6DfYzTSmc8XHn5daNaMLXSdYgXyKkDchlegnxwXATQiFmkV1ktUG6L9Jtt9Db+3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "commander": "^9.2.0",
+                "prettier": "^2.7.1"
+            },
+            "bin": {
+                "comet": "bin/comet.js"
+            },
+            "peerDependencies": {
+                "ts-node": "^10.9.1"
+            }
+        },
         "node_modules/@comet/cms-api": {
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/@comet/cms-api/-/cms-api-7.10.0.tgz",
@@ -2685,15 +2703,6 @@
             },
             "engines": {
                 "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@comet/cms-api/node_modules/commander": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/@comet/cms-api/node_modules/glob": {
@@ -10685,6 +10694,15 @@
             },
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/comment-json": {

--- a/api/package.json
+++ b/api/package.json
@@ -61,6 +61,7 @@
         "uuid": "^8.3.2"
     },
     "devDependencies": {
+        "@comet/cli": "^7.10.0",
         "@comet/eslint-config": "^7.10.0",
         "@cspell/eslint-plugin": "^8.16.1",
         "@jest/types": "^29.6.3",


### PR DESCRIPTION
We incorrectly removed `@comet/cli` from the API in https://github.com/vivid-planet/comet-starter/pull/560. The package is used for the site configs type.