### PR TITLE
Fix required permission for footer in the API

### DIFF
--- a/api/src/footers/entities/footer.entity.ts
+++ b/api/src/footers/entities/footer.entity.ts
@@ -11,7 +11,7 @@ import { v4 } from "uuid";
     implements: () => [DocumentInterface],
 })
 @RootBlockEntity()
-@CrudSingleGenerator({ targetDirectory: `${__dirname}/../generated/` })
+@CrudSingleGenerator({ targetDirectory: `${__dirname}/../generated/`, requiredPermission: "pageTree" })
 export class Footer extends BaseEntity<Footer, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";
 

--- a/api/src/footers/generated/footer.resolver.ts
+++ b/api/src/footers/generated/footer.resolver.ts
@@ -11,7 +11,7 @@ import { FooterInput } from "./dto/footer.input";
 import { FootersService } from "./footers.service";
 
 @Resolver(() => Footer)
-@RequiredPermission(["footers"])
+@RequiredPermission("pageTree")
 export class FooterResolver {
     constructor(
         private readonly entityManager: EntityManager,


### PR DESCRIPTION
Noticed this while reviewing the [Starter into Demo merge](https://github.com/vivid-planet/comet/pull/2899). An editor should be able to edit the footer if they have permission for the page tree.