### PR TITLE
Add user permission check to latest content updates widget

### DIFF
--- a/admin/src/dashboard/DashboardPage.tsx
+++ b/admin/src/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { MainContent, Stack, Toolbar } from "@comet/admin";
-import { ContentScopeIndicator, DashboardHeader } from "@comet/cms-admin";
+import { ContentScopeIndicator, DashboardHeader, useUserPermissionCheck } from "@comet/cms-admin";
 import { Grid } from "@mui/material";
 import { useIntl } from "react-intl";
 
@@ -9,6 +9,7 @@ import { LatestContentUpdates } from "./LatestContentUpdates";
 
 export function DashboardPage() {
     const intl = useIntl();
+    const isAllowed = useUserPermissionCheck();
 
     return (
         <Stack topLevelTitle={intl.formatMessage({ id: "dashboard", defaultMessage: "Dashboard" })}>
@@ -21,7 +22,7 @@ export function DashboardPage() {
             <Toolbar scopeIndicator={<ContentScopeIndicator />} />
             <MainContent>
                 <Grid container direction="row" spacing={4}>
-                    <LatestContentUpdates />
+                    {isAllowed("pageTree") && <LatestContentUpdates />}
                 </Grid>
             </MainContent>
         </Stack>


### PR DESCRIPTION
The latest content updates should only be displayed if the user has the correct permissions.