### PR TITLE
Fix CRUD Generator lint scripts

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -17,7 +17,7 @@
         "lint": "run-p lint:eslint lint:tsc intl:extract lint:knip",
         "lint:ci": "npm run lint && npm run lint:generated-files-not-modified",
         "lint:eslint": "eslint --max-warnings 0 --ext .ts,.tsx,.js,.jsx,.json,.md src/ package.json",
-        "lint:generated-files-not-modified": "npm run admin-generator && git diff --exit-code HEAD --",
+        "lint:generated-files-not-modified": "npm run admin-generator && git diff --exit-code HEAD -- src/**/generated",
         "lint:knip": "knip --exports --files --dependencies --tags=-knipignore",
         "lint:prettier": "npx prettier --check './**/*.{js,json,md,yml,yaml}'",
         "lint:tsc": "tsc --project .",

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,7 @@
         "lint": "run-p lint:eslint lint:tsc lint:prettier lint:knip",
         "lint:ci": "npm run lint && npm run lint:generated-files-not-modified",
         "lint:eslint": "eslint --ext .ts,.tsx,.js,.jsx,.json,.md --max-warnings 0 src/ package.json",
-        "lint:generated-files-not-modified": "npm run api-generator && git diff --exit-code HEAD --",
+        "lint:generated-files-not-modified": "npm run api-generator && git diff --exit-code HEAD -- src/**/generated",
         "lint:knip": "knip --exports --files --dependencies --tags=-knipignore",
         "lint:prettier": "npx prettier --check './**/*.{js,json,md,yml,yaml}'",
         "lint:tsc": "tsc --project ./tsconfig.lint.json",


### PR DESCRIPTION
## Description

The `lint:generated-files-not-modified` incorrectly failed if any file in the Git repository had changes. We fix this by only checking for files in `src/**/generated`.

## Further information

- Demo: https://github.com/vivid-planet/comet/pull/2903