### PR TITLE
Knip: Ignore files generated by CRUD Generator

### DIFF
--- a/admin/knip.json
+++ b/admin/knip.json
@@ -2,6 +2,6 @@
     "$schema": "https://unpkg.com/knip@5/schema.json",
     "entry": ["./src/loader.ts"],
     "project": ["./src/**/*.{ts,tsx}"],
-    "ignore": ["./codegen.ts", "./schema.gql"],
+    "ignore": ["./codegen.ts", "./schema.gql", "./src/**/generated/**/*.{ts,tsx}", "./src/**/*.cometGen.ts"],
     "ignoreDependencies": ["@swc/plugin-emotion"]
 }

--- a/api/knip.json
+++ b/api/knip.json
@@ -2,7 +2,7 @@
     "$schema": "https://unpkg.com/knip@5/schema.json",
     "entry": ["./src/main.ts", "./src/console.ts", "./src/repl.ts", "./src/db/ormconfig.cli.ts", "./src/site-configs.d.ts"],
     "project": ["./src/**/*.{ts,tsx}"],
-    "ignore": ["./src/db/migrations/**/*.ts"],
+    "ignore": ["./src/db/migrations/**/*.ts", "./src/**/generated/**/*.ts"],
     "ignoreDependencies": ["@mikro-orm/cli", "jest-junit"],
     "rules": {
         "enumMembers": "off"


### PR DESCRIPTION
e.g., when using
```
@CrudGenerator({
    targetDirectory: `${__dirname}/../generated/`,
    list: false
})
```
`EntityArgs`, `EntityFilter` or `EntitySort` are still being generated by the CRUD generator, but unused. I think this behaviour from the CRUD generator is perfectly fine, as the CRUD generator does not know if they might be used somewhere else, so we should ignore it.