### PR TITLE
Fix OpenTelemetry group in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,7 +50,7 @@
         },
         {
             "groupName": "OpenTelemetry",
-            "matchPackageNames": ["/^open-telemetry/*/"]
+            "matchPackageNames": ["/^@opentelemetry/*/"]
         },
         {
             "groupName": "node",


### PR DESCRIPTION
The regex for the OpenTelemetry packages was incorrect.