### PR TITLE
Use Roboto Flex instead of Roboto

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -15,7 +15,7 @@
                 "@comet/cms-admin": "^7.10.0",
                 "@emotion/react": "^11.13.5",
                 "@emotion/styled": "^11.13.5",
-                "@fontsource/roboto": "^5.1.0",
+                "@fontsource-variable/roboto-flex": "^5.0.0",
                 "@mui/material": "^5.16.11",
                 "@mui/system": "^5.16.8",
                 "@mui/x-data-grid": "^5.17.26",
@@ -2956,11 +2956,11 @@
             "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==",
             "license": "MIT"
         },
-        "node_modules/@fontsource/roboto": {
+        "node_modules/@fontsource-variable/roboto-flex": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.1.0.tgz",
-            "integrity": "sha512-cFRRC1s6RqPygeZ8Uw/acwVHqih8Czjt6Q0MwoUoDe9U3m4dH1HmNDRBZyqlMSFwgNAUKgFImncKdmDHyKpwdg==",
-            "license": "Apache-2.0"
+            "resolved": "https://registry.npmjs.org/@fontsource-variable/roboto-flex/-/roboto-flex-5.1.0.tgz",
+            "integrity": "sha512-TwH8+uOwBqIjxtvTc+kp7ywyH7V7bDLbAXrEQg2SoCTJ6m2pn00x7ULioTTzDEvek+XpbqIf8gbKE1zlcONNGg==",
+            "license": "OFL-1.1"
         },
         "node_modules/@formatjs/cli": {
             "version": "6.3.14",

--- a/admin/package.json
+++ b/admin/package.json
@@ -34,7 +34,7 @@
         "@comet/cms-admin": "^7.10.0",
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
-        "@fontsource/roboto": "^5.1.0",
+        "@fontsource-variable/roboto-flex": "^5.0.0",
         "@mui/material": "^5.16.11",
         "@mui/system": "^5.16.8",
         "@mui/x-data-grid": "^5.17.26",

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -1,7 +1,4 @@
-import "@fontsource/roboto/300.css";
-import "@fontsource/roboto/400.css";
-import "@fontsource/roboto/500.css";
-import "@fontsource/roboto/700.css";
+import "@fontsource-variable/roboto-flex/full.css";
 import "@src/polyfills";
 
 import { ApolloProvider } from "@apollo/client";


### PR DESCRIPTION
This was changed for Demo in https://github.com/vivid-planet/comet/pull/1923. There's also an [upgrade script](https://github.com/vivid-planet/comet-upgrade/pull/11), but it obviously was never executed in the Starter.