### PR TITLE
Convert Next config file to ECMAScript module

### DIFF
--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -1,11 +1,12 @@
-/* eslint-disable */
-
 // @ts-check
-const withBundleAnalyzer = require("@next/bundle-analyzer")({
+
+import nextBundleAnalyzer from "@next/bundle-analyzer";
+
+import cometConfig from "./src/comet-config.json" with { type: "json" };
+
+const withBundleAnalyzer = nextBundleAnalyzer({
     enabled: process.env.ANALYZE === "true",
 });
-
-const cometConfig = require("./src/comet-config.json");
 
 /**
  * @type {import('next').NextConfig}
@@ -56,4 +57,4 @@ const nextConfig = {
     cacheMaxMemorySize: process.env.REDIS_ENABLED === "true" ? 0 : undefined, // disable default in-memory caching
 };
 
-module.exports = withBundleAnalyzer(nextConfig);
+export default withBundleAnalyzer(nextConfig);


### PR DESCRIPTION
## Description

https://nextjs.org/docs/pages/api-reference/config/next-config-js#ecmascript-modules

When we want to use ECMA script modules (used by panda-css or next-yak for eg.) we need to update the next-config file from js to mjs.