### PR TITLE
Fix teaser item style

### DIFF
--- a/site/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/site/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -14,37 +14,36 @@ const descriptionRenderers: Renderers = {
 
 export const TeaserItemBlock = withPreview(
     ({ data: { media, title, description, link } }: PropsWithData<TeaserItemBlockData>) => (
-        <LinkBlock data={link.link}>
-            <ItemContent>
-                <MediaMobile>
-                    <MediaBlock data={media} aspectRatio="1x1" sizes="20vw" />
-                </MediaMobile>
-                <MediaDesktop>
-                    <MediaBlock data={media} aspectRatio="16x9" sizes="20vw" />
-                </MediaDesktop>
-                <ContentContainer>
-                    <TitleTypography variant="h350">{title}</TitleTypography>
-                    <Typography variant="p200">
-                        <RichTextBlock data={description} renderers={descriptionRenderers} />
-                    </Typography>
-                    <TextLinkContainer>
-                        <SvgUse href="/assets/icons/arrow-right.svg#arrow-right" width={16} height={16} />
-                        <LinkText>{link.text}</LinkText>
-                    </TextLinkContainer>
-                </ContentContainer>
-            </ItemContent>
-        </LinkBlock>
+        <RootLinkBlock data={link.link}>
+            <MediaMobile>
+                <MediaBlock data={media} aspectRatio="1x1" sizes="20vw" />
+            </MediaMobile>
+            <MediaDesktop>
+                <MediaBlock data={media} aspectRatio="16x9" sizes="20vw" />
+            </MediaDesktop>
+            <ContentContainer>
+                <TitleTypography variant="h350">{title}</TitleTypography>
+                <Typography variant="p200">
+                    <RichTextBlock data={description} renderers={descriptionRenderers} />
+                </Typography>
+                <TextLinkContainer>
+                    <SvgUse href="/assets/icons/arrow-right.svg#arrow-right" width={16} height={16} />
+                    <LinkText>{link.text}</LinkText>
+                </TextLinkContainer>
+            </ContentContainer>
+        </RootLinkBlock>
     ),
     { label: "Teaser Item" },
 );
 
-const ItemContent = styled.a`
+const RootLinkBlock = styled(LinkBlock)`
     text-decoration: none;
     cursor: pointer;
     display: flex;
     flex: 1;
     flex-direction: row;
     gap: ${({ theme }) => theme.spacing.S300};
+    color: ${({ theme }) => theme.palette.text.primary};
 
     ${({ theme }) => theme.breakpoints.sm.mediaQuery} {
         flex: unset;


### PR DESCRIPTION
## Description

Fix teaser item:
- fix a-tag in a-tag (LinkBlock creates its own a-tag now)
- fix text styling inside

## Screenshots/screencasts

| Before   | After   |
| -------- | ------- |
| <img width="292" alt="Screenshot 2024-12-20 at 07 50 45" src="https://github.com/user-attachments/assets/afef408e-5fa1-47bb-b5d8-ea97cf61e20c" /> | <img width="296" alt="Screenshot 2024-12-20 at 07 50 33" src="https://github.com/user-attachments/assets/bd5dc182-223d-4007-87e1-9172f0acb5f8" /> |

## Related tasks and documents

COM-1206