### PR TITLE
Add `ErrorHandler` to site

### DIFF
--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "@fontsource/roboto";
 import "@fontsource/roboto/700.css";
 
 import { GlobalStyle } from "@src/layout/GlobalStyle";
+import { ErrorHandler } from "@src/util/ErrorHandler";
 import { ResponsiveSpacingStyle } from "@src/util/ResponsiveSpacingStyle";
 import StyledComponentsRegistry from "@src/util/StyledComponentsRegistry";
 
@@ -14,7 +15,7 @@ export default async function RootLayout({
         <StyledComponentsRegistry>
             <GlobalStyle />
             <ResponsiveSpacingStyle />
-            {children}
+            <ErrorHandler>{children}</ErrorHandler>
         </StyledComponentsRegistry>
     );
 }

--- a/site/src/util/ErrorHandler.tsx
+++ b/site/src/util/ErrorHandler.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { ErrorHandlerProvider } from "@comet/cms-site";
+import { PropsWithChildren } from "react";
+
+export function ErrorHandler({ children }: PropsWithChildren) {
+    function onError(error: Error, errorInfo: React.ErrorInfo) {
+        if (process.env.NODE_ENV === "development") {
+            console.error("Error caught by error handler", error, errorInfo.componentStack);
+            throw error;
+        } else {
+            // TODO: Log the error to an error tracking service (e.g. Sentry)
+        }
+    }
+
+    return <ErrorHandlerProvider onError={onError}>{children}</ErrorHandlerProvider>;
+}


### PR DESCRIPTION
## Description

see https://github.com/vivid-planet/comet/pull/2281

By switching to SSR instead of SSG, an error thrown in a block causes the entire page to crash (white screen). To avoid this, errors in the block are caught and handled in the ErrorHandler. 

In development, the error is still thrown. In production, blocks with errors are simply hidden. A tool like Sentry should be configured where the error can be logged.