### PR TITLE
Multiple small adjustments related to documents

### DIFF
--- a/admin/src/documents/links/EditLink.tsx
+++ b/admin/src/documents/links/EditLink.tsx
@@ -37,7 +37,7 @@ const usePage = createUsePage({
     `,
     updateMutation: gql`
         mutation UpdateLink($pageId: ID!, $input: LinkInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID) {
-            saveLink(linkId: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
+            saveLink(id: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
                 id
                 content
                 updatedAt

--- a/admin/src/documents/links/Link.tsx
+++ b/admin/src/documents/links/Link.tsx
@@ -38,7 +38,7 @@ export const Link: DocumentInterface<Pick<GQLLink, "content">, GQLLinkInput> & D
     `,
     updateMutation: gql`
         mutation UpdateLink($pageId: ID!, $input: LinkInput!, $lastUpdatedAt: DateTime, $attachedPageTreeNodeId: ID) {
-            saveLink(linkId: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
+            saveLink(id: $pageId, input: $input, lastUpdatedAt: $lastUpdatedAt, attachedPageTreeNodeId: $attachedPageTreeNodeId) {
                 id
                 content
                 updatedAt

--- a/admin/src/documents/pages/Page.tsx
+++ b/admin/src/documents/pages/Page.tsx
@@ -1,4 +1,5 @@
 import { gql } from "@apollo/client";
+import { messages } from "@comet/admin";
 import { File, FileNotMenu } from "@comet/admin-icons";
 import { createDocumentDependencyMethods, createDocumentRootBlocksMethods, DependencyInterface, DocumentInterface } from "@comet/cms-admin";
 import { GQLPage, GQLPageInput } from "@src/graphql.generated";
@@ -11,7 +12,7 @@ import { StageBlock } from "./blocks/StageBlock";
 import { EditPage } from "./EditPage";
 
 export const Page: DocumentInterface<Pick<GQLPage, "content" | "seo">, GQLPageInput> & DependencyInterface = {
-    displayName: <FormattedMessage id="generic.page" defaultMessage="Page" />,
+    displayName: <FormattedMessage {...messages.page} />,
     editComponent: EditPage,
     menuIcon: File,
     hideInMenuIcon: FileNotMenu,

--- a/api/schema.gql
+++ b/api/schema.gql
@@ -351,7 +351,7 @@ type Query {
   userPermissionsAvailablePermissions: [String!]!
   userPermissionsContentScopes(userId: String!, skipManual: Boolean): [JSONObject!]!
   userPermissionsAvailableContentScopes: [JSONObject!]!
-  link(linkId: ID!): Link
+  link(id: ID!): Link
   page(id: ID!): Page!
   pageTreeNode(id: ID!): PageTreeNode
   pageTreeNodeByPath(path: String!, scope: PageTreeNodeScopeInput!): PageTreeNode
@@ -504,7 +504,7 @@ type Mutation {
   userPermissionsDeletePermission(id: ID!): Boolean!
   userPermissionsUpdateOverrideContentScopes(input: UserPermissionOverrideContentScopesInput!): UserPermission!
   userPermissionsUpdateContentScopes(userId: String!, input: UserContentScopesInput!): Boolean!
-  saveLink(linkId: ID!, input: LinkInput!, lastUpdatedAt: DateTime, attachedPageTreeNodeId: ID): Link!
+  saveLink(id: ID!, input: LinkInput!, lastUpdatedAt: DateTime, attachedPageTreeNodeId: ID): Link!
   savePage(pageId: ID!, input: PageInput!, lastUpdatedAt: DateTime, attachedPageTreeNodeId: ID): Page!
   updatePageTreeNode(id: ID!, input: PageTreeNodeUpdateInput!): PageTreeNode!
   deletePageTreeNode(id: ID!): Boolean!

--- a/api/src/documents/links/entities/link.entity.ts
+++ b/api/src/documents/links/entities/link.entity.ts
@@ -1,14 +1,24 @@
 import { BlockDataInterface } from "@comet/blocks-api";
-import { DocumentInterface, RootBlockDataScalar, RootBlockType } from "@comet/cms-api";
+import {
+    DocumentInterface,
+    EntityInfo,
+    PageTreeNodeDocumentEntityInfoService,
+    PageTreeNodeDocumentEntityScopeService,
+    RootBlockDataScalar,
+    RootBlockType,
+    ScopedEntity,
+} from "@comet/cms-api";
 import { BaseEntity, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Field, ID, ObjectType } from "@nestjs/graphql";
 import { LinkBlock } from "@src/common/blocks/link.block";
 import { v4 } from "uuid";
 
+@EntityInfo(PageTreeNodeDocumentEntityInfoService)
 @Entity()
 @ObjectType({
     implements: () => [DocumentInterface],
 })
+@ScopedEntity(PageTreeNodeDocumentEntityScopeService)
 export class Link extends BaseEntity<Link, "id"> implements DocumentInterface {
     [OptionalProps]?: "createdAt" | "updatedAt";
 

--- a/api/src/documents/links/links.resolver.ts
+++ b/api/src/documents/links/links.resolver.ts
@@ -25,8 +25,9 @@ export class LinksResolver {
     ) {}
 
     @Query(() => Link, { nullable: true })
-    async link(@Args("linkId", { type: () => ID }) linkId: string): Promise<Link | null> {
-        return this.repository.findOne(linkId);
+    @AffectedEntity(Link)
+    async link(@Args("id", { type: () => ID }) id: string): Promise<Link | null> {
+        return this.repository.findOne(id);
     }
 
     @ResolveField(() => PageTreeNode, { nullable: true })
@@ -37,7 +38,7 @@ export class LinksResolver {
     @Mutation(() => Link)
     @AffectedEntity(Link, { pageTreeNodeIdArg: "attachedPageTreeNodeId" })
     async saveLink(
-        @Args("linkId", { type: () => ID }) linkId: string,
+        @Args("id", { type: () => ID }) id: string,
         @Args("input", { type: () => LinkInput }) input: LinkInput,
         @Args("lastUpdatedAt", { type: () => Date, nullable: true }) lastUpdatedAt?: Date,
         @Args("attachedPageTreeNodeId", { nullable: true, type: () => ID }) attachedPageTreeNodeId?: string,
@@ -50,7 +51,7 @@ export class LinksResolver {
             }
         }
 
-        let link = await this.repository.findOne(linkId);
+        let link = await this.repository.findOne(id);
 
         if (link) {
             if (lastUpdatedAt) {
@@ -60,7 +61,7 @@ export class LinksResolver {
             link.assign({ content: input.content.transformToBlockData() });
         } else {
             link = this.repository.create({
-                id: linkId,
+                id,
                 content: input.content.transformToBlockData(),
             });
 
@@ -68,7 +69,7 @@ export class LinksResolver {
         }
 
         if (attachedPageTreeNodeId) {
-            await this.pageTreeService.attachDocument({ id: linkId, type: "Link" }, attachedPageTreeNodeId);
+            await this.pageTreeService.attachDocument({ id, type: "Link" }, attachedPageTreeNodeId);
         }
 
         await this.entityManager.flush();


### PR DESCRIPTION
## Description

Following adjustments are made:

- Rename `linkId` argument to `id` for `saveLink` and `link` operations
- Use shared messages instead of custom message for Page displayName
- Add `@EntityInfo` and `@ScopedEntity` to link entity
- Add `@AffectedEntity` to link query