### PR TITLE
Pin TypeScript version to `5.1.6` (for now)

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -67,7 +67,7 @@
                 "prettier": "^2.8.8",
                 "rimraf": "^6.0.1",
                 "ts-node": "^10.9.2",
-                "typescript": "^5.7.2",
+                "typescript": "5.1.6",
                 "vite": "^5.4.11",
                 "vite-plugin-html": "^3.2.2"
             },
@@ -18496,9 +18496,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -86,7 +86,7 @@
         "prettier": "^2.8.8",
         "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.7.2",
+        "typescript": "5.1.6",
         "vite": "^5.4.11",
         "vite-plugin-html": "^3.2.2"
     },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -63,7 +63,7 @@
                 "ts-jest": "^29.2.5",
                 "ts-node": "^10.9.2",
                 "tsconfig-paths": "^3.15.0",
-                "typescript": "^5.7.2"
+                "typescript": "5.1.6"
             },
             "engines": {
                 "node": "22"
@@ -22056,9 +22056,9 @@
             "license": "MIT"
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/api/package.json
+++ b/api/package.json
@@ -85,7 +85,7 @@
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^3.15.0",
-        "typescript": "^5.7.2"
+        "typescript": "5.1.6"
     },
     "engines": {
         "node": "22"

--- a/create-app/package-lock.json
+++ b/create-app/package-lock.json
@@ -28,7 +28,7 @@
                 "cspell": "^8.17.1",
                 "npm-run-all2": "^7.0.2",
                 "prettier": "^2.8.8",
-                "typescript": "^5.7.2"
+                "typescript": "5.1.6"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -6705,9 +6705,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/create-app/package.json
+++ b/create-app/package.json
@@ -47,7 +47,7 @@
         "cspell": "^8.17.1",
         "npm-run-all2": "^7.0.2",
         "prettier": "^2.8.8",
-        "typescript": "^5.7.2"
+        "typescript": "5.1.6"
     },
     "publishConfig": {
         "access": "public",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "open-cli": "^8.0.0",
                 "prettier": "^2.8.8",
                 "ts-node": "^10.9.2",
-                "typescript": "^5.7.2"
+                "typescript": "5.1.6"
             },
             "engines": {
                 "node": "22"
@@ -3818,9 +3818,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "open-cli": "^8.0.0",
         "prettier": "^2.8.8",
         "ts-node": "^10.9.2",
-        "typescript": "^5.7.2"
+        "typescript": "5.1.6"
     },
     "engines": {
         "node": "22"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -49,7 +49,7 @@
                 "prettier": "^2.8.8",
                 "stylelint": "^16.12.0",
                 "stylelint-config-standard": "^36.0.1",
-                "typescript": "^5.7.2"
+                "typescript": "5.1.6"
             },
             "engines": {
                 "node": "22"
@@ -14366,6 +14366,20 @@
                 "postcss": "^8.4.21"
             }
         },
+        "node_modules/postcss-styled-syntax/node_modules/typescript": {
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
         "node_modules/postcss-value-parser": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -16436,9 +16450,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/site/package.json
+++ b/site/package.json
@@ -64,7 +64,7 @@
         "prettier": "^2.8.8",
         "stylelint": "^16.12.0",
         "stylelint-config-standard": "^36.0.1",
-        "typescript": "^5.7.2"
+        "typescript": "5.1.6"
     },
     "engines": {
         "node": "22"


### PR DESCRIPTION
## Description

Running ESLint or any command that uses ESLint (e.g., the API Generator) currently produces the following massive warning:

```
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by @typescript-eslint/typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <5.2.0

YOUR TYPESCRIPT VERSION: 5.2.2

Please only submit bug reports when using the officially supported version.

=============
```

To fix this, we pin the TypeScript version to the last version supported by typescript-eslint. We then need to update our dependency on typescript-eslint in the library and correctly set a peer dependency on TypeScript in `@comet/eslint-config`.

## Further information

A PR in Demo isn't necessary because Demo still uses TypeScript 4.

