### PR TITLE
Fix Cache Handler import in Next config

### DIFF
--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -53,7 +53,7 @@ const nextConfig = {
             ],
         },
     ],
-    cacheHandler: process.env.REDIS_ENABLED === "true" ? require.resolve("./dist/cache-handler.js") : undefined,
+    cacheHandler: process.env.REDIS_ENABLED === "true" ? import.meta.resolve("./dist/cache-handler.js").replace("file://", "") : undefined,
     cacheMaxMemorySize: process.env.REDIS_ENABLED === "true" ? 0 : undefined, // disable default in-memory caching
 };
 


### PR DESCRIPTION
## Description

We can't use `require.resolve` in ESM so we replace it with `import.meta.resolve`. 

Note: the string replacement is needed because the path can not be resolved correctly, see the following issue:  https://github.com/vercel/next.js/issues/73796.