### PR TITLE
@comet/create-app: Fix ESLint skip if dependencies aren't installed

### DIFF
--- a/create-app/src/util/runEslintFix.ts
+++ b/create-app/src/util/runEslintFix.ts
@@ -10,8 +10,10 @@ export function runEslintFix(verbose: boolean) {
     for (const microservice of microservices) {
         if (!fs.existsSync(microservice)) {
             continue;
-        } else if (!hasDependenciesInstalled(microservice) && verbose) {
-            console.log(kleur.grey(`Skipping ESLint fix in ${microservice} because dependencies are not installed.`));
+        } else if (!hasDependenciesInstalled(microservice)) {
+            if (verbose) {
+                console.log(kleur.grey(`Skipping ESLint fix in ${microservice} because dependencies are not installed.`));
+            }
             continue;
         }
 


### PR DESCRIPTION
## Description

The check whether dependencies are installed didn't work because verbose logging is disabled by default. Moving the check for verbose logging into a separate if resolves the issue.
