### PR TITLE
Add `@comet/create-app` to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,13 +58,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix site ci
+        run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix site ci && npm --prefix create-app ci
 
       - name: Copy schema files
         run: npm run copy-schema-files
 
       - name: Lint
-        run: npm run lint:root && npm --prefix api run lint:ci && npm --prefix admin run lint:ci && npm --prefix site run lint:ci
+        run: npm run lint:root && npm --prefix api run lint:ci && npm --prefix admin run lint:ci && npm --prefix site run lint:ci && npm --prefix create-app run lint
 
       - name: Build
-        run: npm run build
+        run: npm run build && npm --prefix create-app run build


### PR DESCRIPTION
Previously, changes to `@comet/create-app` weren't linted during CI.
