### PR TITLE
Fix DigitalOcean Admin Deployment

### DIFF
--- a/.digitalocean/comet-starter-cms.tpl.yaml
+++ b/.digitalocean/comet-starter-cms.tpl.yaml
@@ -282,5 +282,5 @@ services:
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb
     name: admin
-    run_command: cd server && npm i && node index.js # Workaround for missing node_modules in cache (only parent node_mdoules are cached)
+    run_command: cd server && npm i && cd .. && node server # Workaround for missing node_modules in cache (only parent node_mdoules are cached)
     source_dir: admin


### PR DESCRIPTION
With https://github.com/vivid-planet/comet-starter/pull/588 the server has to be called from `./admin`