### PR TITLE
Add generateMetadata to page and layout

### DIFF
--- a/site/src/app/[domain]/[language]/[[...path]]/layout.tsx
+++ b/site/src/app/[domain]/[language]/[[...path]]/layout.tsx
@@ -1,22 +1,19 @@
 import { gql, previewParams } from "@comet/cms-site";
+import { GQLLayoutQuery, GQLLayoutQueryVariables } from "@src/app/[domain]/[language]/[[...path]]/layout.generated";
 import { Footer } from "@src/layout/footer/Footer";
 import { footerFragment } from "@src/layout/footer/Footer.fragment";
 import { Header } from "@src/layout/header/Header";
 import { headerFragment } from "@src/layout/header/Header.fragment";
 import { createGraphQLFetch } from "@src/util/graphQLClient";
+import { getSiteConfigForDomain } from "@src/util/siteConfig";
 import type { Metadata } from "next";
 import { PropsWithChildren } from "react";
 
-import { GQLLayoutQuery, GQLLayoutQueryVariables } from "./layout.generated";
+interface LayoutProps {
+    params: { domain: string; language: string };
+}
 
-export const metadata: Metadata = {
-    title: "Comet Starter",
-};
-
-export default async function Layout({
-    children,
-    params: { domain, language },
-}: PropsWithChildren<{ params: { domain: string; language: string } }>) {
+export default async function Layout({ children, params: { domain, language } }: PropsWithChildren<LayoutProps>) {
     const { previewData } = (await previewParams()) || { previewData: undefined };
     const graphqlFetch = createGraphQLFetch(previewData);
 
@@ -30,7 +27,6 @@ export default async function Layout({
                     ...Footer
                 }
             }
-
             ${headerFragment}
             ${footerFragment}
         `,
@@ -44,4 +40,12 @@ export default async function Layout({
             {footer && <Footer footer={footer} />}
         </>
     );
+}
+
+export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
+    const siteConfig = getSiteConfigForDomain(params.domain);
+
+    return {
+        metadataBase: new URL(siteConfig.url),
+    };
 }


### PR DESCRIPTION
## Description

Add `generateMetadata()` to page.tsx to actually add SEO tags to the page

Add `generateMetadata()` to layout.tsx to set a `metadataBase` URL (as recommended in https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase). If no metadataBase is set, Next.js will fallback to the default domain (localhost:3000) when using relative links in metadata tags (e.g., `og:image`)

---

Corresponding Demo PR: https://github.com/vivid-planet/comet/pull/3268