### PR TITLE
Remove automatically assigned reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -3,12 +3,7 @@ addAssignees: author
 addReviewers: true
 
 reviewers:
-  - dkarnutsch
-  - fraxachun
   - johnnyomair
-  - nsams
-  - thomasdax98
-  - manuelblum
 
 skipKeywords:
   - Merge main into next


### PR DESCRIPTION
Reviewers shouldn't be automatically assigned any longer since we're now using a "Demo first" approach.