### PR TITLE
Ignore unknown fragments in GraphQL documents validation

### DIFF
--- a/admin/codegen.ts
+++ b/admin/codegen.ts
@@ -45,6 +45,9 @@ const config: CodegenConfig = {
                 namingConvention: "keep",
                 scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), { DateTime: "string" }),
                 typesPrefix: "GQL",
+                skipDocumentsValidation: {
+                    ignoreRules: ["KnownFragmentNamesRule"],
+                },
             },
             plugins: [
                 { add: { content: `import { ${rootBlocks.sort().join(", ")} } from "@src/blocks.generated";` } },


### PR DESCRIPTION
## Description

This prevents an error we noticed while upgrading GraphQL Codegen in Demo: The documents validation would fail for fragments coming from the library, e.g, `FinalFormFileUpload`. Ignoring the `KnownFragmentNamesRule` resolves the issue.

## Further informatoin

- PR in Demo: https://github.com/vivid-planet/comet/pull/3315