### PR TITLE
Fix structured data hydration with dangerouslySetInnerHTML

### DIFF
--- a/site/src/documents/pages/Page.tsx
+++ b/site/src/documents/pages/Page.tsx
@@ -131,7 +131,7 @@ export async function Page({ pageTreeNodeId, scope }: { pageTreeNodeId: string; 
     return (
         <>
             {document.seo.structuredData && document.seo.structuredData.length > 0 && (
-                <script type="application/ld+json">{document.seo.structuredData}</script>
+                <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: document.seo.structuredData }} />
             )}
             <main>
                 <StageBlock data={document.stage} />


### PR DESCRIPTION
## Description

Setting the structured data on an admin component caused a hydration issue on the site.
Using `dangerouslySetInnerHTML` to set the structured data prevents this issue.

## Screenshots/screencasts
<img width="962" alt="Screenshot 2025-02-11 at 09 05 11" src="https://github.com/user-attachments/assets/d0a8fd93-ce3f-4492-b739-895069cea30d" />

## Further information

[NextJS Docs](https://nextjs.org/docs/app/building-your-application/optimizing/metadata#json-ld)

PR in Demo: https://github.com/vivid-planet/comet/pull/3398