### PR TITLE
Make `LocaleProvider` return language instead of domain

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -76,7 +76,7 @@ export function App() {
                             }}
                         >
                             <IntlProvider locale="en" messages={getMessages()}>
-                                <LocaleProvider resolveLocaleForScope={(scope) => scope.domain}>
+                                <LocaleProvider resolveLocaleForScope={(scope) => scope.language}>
                                     <MuiThemeProvider theme={theme}>
                                         <DndProvider options={HTML5toTouch}>
                                             <SnackbarProvider>


### PR DESCRIPTION
Demo: Part of PR: https://github.com/vivid-planet/comet/pull/3451

## Open questions

In Demo (TS v4) I typed `scope` explicitly: 

```
<LocaleProvider resolveLocaleForScope={(scope: ContentScope) => scope.language}>
```

This doesn't work in the Starter (TS v5):

> TS2322: Type (scope: ContentScope) => string is not assignable to type ResolveLocaleFunction
Types of parameters scope and scope are incompatible.
Type ContentScopeInterface is missing the following properties from type ContentScope: domain, language

Do we care? Any idea how I can make this work? 