### PR TITLE
Use first available content scope for user as default value

### DIFF
--- a/admin/src/common/ContentScopeProvider.tsx
+++ b/admin/src/common/ContentScopeProvider.tsx
@@ -26,8 +26,12 @@ export const ContentScopeProvider = ({ children }: Pick<ContentScopeProviderProp
         language: { value: contentScope.language, label: contentScope.language.toUpperCase() },
     }));
 
+    if (user.allowedContentScopes.length === 0) {
+        throw new Error("User does not have access to any scopes.");
+    }
+
     return (
-        <ContentScopeProviderLibrary<ContentScope> values={values} defaultValue={{ domain: "main", language: "en" }}>
+        <ContentScopeProviderLibrary<ContentScope> values={values} defaultValue={userContentScopes[0]}>
             {children}
         </ContentScopeProviderLibrary>
     );


### PR DESCRIPTION
## Description

When a user does not have the defaultScope as permission, only a white page is rendered. This PR redirects the user to the first scope they have access to.

From here: https://github.com/vivid-planet/comet/pull/3417

## Screenshots/screencasts

Before:

https://github.com/user-attachments/assets/ccb6e3a2-872f-4e5e-a6f2-fa9a403251c4



After:

https://github.com/user-attachments/assets/e64e0a88-c08a-4ec6-941c-c58d3bcd0c9e




When the user has no scopes assigned:
Before:
![Screenshot 2025-02-12 at 15 20 35](https://github.com/user-attachments/assets/a922e092-71d9-47f2-b6af-fe13515b20b0)

After:
![Screenshot 2025-02-12 at 15 20 19](https://github.com/user-attachments/assets/b1f221f6-b867-41f7-8495-8eaa208db77a)

Still a white page for the user but that is another topic.

