### PR TITLE
Rewrite non-existent /_next/static and /assets URLs to 404

### DIFF
--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -67,7 +67,18 @@ const nextConfig = {
         },
     ],
     cacheHandler: process.env.REDIS_ENABLED === "true" ? import.meta.resolve("./dist/cache-handler.js").replace("file://", "") : undefined,
-    cacheMaxMemorySize: process.env.REDIS_ENABLED === "true" ? 0 : undefined, // disable default in-memory caching
+    cacheMaxMemorySize: process.env.REDIS_ENABLED === "true" ? 0 : undefined, // disable default in-memory caching,
+    rewrites: () => {
+        return {
+            afterFiles: [
+                {
+                    // Show a 404 instead of trying to render page for paths starting with /_next/ or /assets/ as they don't get rewritten in DomainRewriteMiddleware and cause errors in ...path page
+                    source: "/:prefix(_next|assets)/:path*",
+                    destination: "/404",
+                },
+            ],
+        };
+    },
 };
 
 export default withBundleAnalyzer(nextConfig);

--- a/site/next.config.mjs
+++ b/site/next.config.mjs
@@ -67,7 +67,7 @@ const nextConfig = {
         },
     ],
     cacheHandler: process.env.REDIS_ENABLED === "true" ? import.meta.resolve("./dist/cache-handler.js").replace("file://", "") : undefined,
-    cacheMaxMemorySize: process.env.REDIS_ENABLED === "true" ? 0 : undefined, // disable default in-memory caching,
+    cacheMaxMemorySize: process.env.REDIS_ENABLED === "true" ? 0 : undefined, // disable default in-memory caching
     rewrites: () => {
         return {
             afterFiles: [

--- a/site/src/app/assets/[[...path]]/page.tsx
+++ b/site/src/app/assets/[[...path]]/page.tsx
@@ -1,5 +1,0 @@
-import { notFound } from "next/navigation";
-
-export default async function AssetNotFound() {
-    notFound();
-}

--- a/site/src/app/assets/layout.tsx
+++ b/site/src/app/assets/layout.tsx
@@ -1,6 +1,0 @@
-import { notFound } from "next/navigation";
-
-export default function AssetsLayout() {
-    // Do not present a dedicated 404 page, just send the notfound-header without content
-    notFound();
-}

--- a/site/src/app/not-found.tsx
+++ b/site/src/app/not-found.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function NotFound404() {
+    return (
+        <html lang="en">
+            <body>
+                <p>Page not found.</p>
+                <Link href="/">Return Home</Link>
+            </body>
+        </html>
+    );
+}


### PR DESCRIPTION
Demo PR: https://github.com/vivid-planet/comet/pull/3269

Task: https://vivid-planet.atlassian.net/browse/COM-1615

---

Up until now, requests to non-existent /_next/static and /assets URLs caused 500 responses. The reason was that `_next` / `assets` was then interpreted as the domain parameter. Since there obviously is no site config for a `_next` or `assets` domain, this caused an error.

See the Demo PR for more info
