### PR TITLE
Fix CSP to Enable GraphQL Playground in Local Development

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -50,12 +50,15 @@ async function bootstrap(): Promise<void> {
 
     app.use(
         helmet({
-            contentSecurityPolicy: {
-                directives: {
-                    "default-src": ["'none'"],
-                },
-                useDefaults: false, // Disable default directives
-            },
+            contentSecurityPolicy:
+                process.env.NODE_ENV !== "production"
+                    ? false
+                    : {
+                          directives: {
+                              "default-src": ["'none'"],
+                          },
+                          useDefaults: false, // Disable default directives
+                      },
             xFrameOptions: false, // Disable non-standard header
             strictTransportSecurity: {
                 // Enable HSTS


### PR DESCRIPTION
Disabled Content Security Policy (CSP) for the API in local development to fully enable the GraphQL Playground (as it was the case prior to #280). In production, the restrictive CSP with default-src: 'none' remains unchanged.

**This does not pose any security implications since APIs typically do not require CSP or use default-src 'none'.** 