### PR TITLE
Adjust Stylelint config

### DIFF
--- a/site/.stylelintrc.json
+++ b/site/.stylelintrc.json
@@ -2,6 +2,9 @@
     "extends": "stylelint-config-standard",
     "customSyntax": "postcss-styled-syntax",
     "rules": {
-        "declaration-empty-line-before": null
+        "declaration-block-no-redundant-longhand-properties": null,
+        "declaration-empty-line-before": null,
+        "media-feature-range-notation": "prefix",
+        "shorthand-property-no-redundant-values": null
     }
 }


### PR DESCRIPTION
## Description

Adjusts the Stylelint config to better reflect the CSS our devs like to write in projects

1. Disable `declaration-block-no-redundant-longhand-properties`: This allows writing `justify-items` and `align-items` instead of `place-items`
2. Change `media-feature-range-notation` to `"prefix"`: This prefers `@media (min-width: 1px)` over `@media (width >= 1px)`
3. Disable `shorthand-property-no-redundant-values`: This allows writing `padding: 32px 32px 0 32px` instead of `padding: 32px 32px 0`, which is harder to unterstand