### PR TITLE
Proxy API requests through Admin Domain

### DIFF
--- a/.env
+++ b/.env
@@ -35,7 +35,7 @@ DAM_SECRET=6a9e8a185b513363bc89ec0b96eed8f70c759bc86b97319f60365c4b7f8593dc
 
 # api
 API_PORT=4000
-API_URL=http://${DEV_DOMAIN:-localhost}:${API_PORT}/api
+API_URL=$ADMIN_URL/api
 API_URL_INTERNAL=http://localhost:$API_PORT/api
 CORS_ALLOWED_ORIGIN="^http:\/\/(localhost|.*\.dev\.vivid-planet\.cloud|192\.168\.\d{1,3}\.\d{1,3}):\d{2,4}"
 BASIC_AUTH_SYSTEM_USER_PASSWORD=password

--- a/admin/vite.config.mts
+++ b/admin/vite.config.mts
@@ -49,6 +49,13 @@ export default defineConfig(({ mode }) => {
         server: {
             host: true,
             port: Number(process.env.ADMIN_PORT),
+            proxy: {
+                "/api": {
+                    target: new URL(process.env.API_URL_INTERNAL).origin,
+                    changeOrigin: true,
+                    secure: false,
+                },
+            },
         },
         define: {
             // define NODE_ENV for packages using it

--- a/admin/vite.config.mts
+++ b/admin/vite.config.mts
@@ -49,13 +49,15 @@ export default defineConfig(({ mode }) => {
         server: {
             host: true,
             port: Number(process.env.ADMIN_PORT),
-            proxy: {
-                "/api": {
-                    target: new URL(process.env.API_URL_INTERNAL).origin,
-                    changeOrigin: true,
-                    secure: false,
-                },
-            },
+            proxy: process.env.API_URL_INTERNAL
+                ? {
+                      "/api": {
+                          target: new URL(process.env.API_URL_INTERNAL).origin,
+                          changeOrigin: true,
+                          secure: false,
+                      },
+                  }
+                : undefined,
         },
         define: {
             // define NODE_ENV for packages using it


### PR DESCRIPTION
Demo PR: https://github.com/vivid-planet/comet/pull/3644

---

## Description

Requests from Admin to API are now proxied through the Admin domain locally using Vite server proxy. 

## Why?

In our deployed setup, requests to Admin and requests from Admin to the API are proxied through our Auth proxy to ensure that the user is logged in. The Auth Proxy runs under the Admin Domain. Meaning, API requests go to the Admin Domain and are proxied to the API. This lead to a gap between the local dev setup (API requests go directly to the API domain) and the deployed setup (API requests go to the Admin domain). This sometimes lead to problems when configuring CSP or testing file URLs.

The change in this PR helps harmonize the local and the deployed setup to better avoid such mistakes (though since Admin and API run under localhost, it probably won't prevent all problems). 