### PR TITLE
@comet/create-app: Add project name to user dictionary

### DIFF
--- a/.cspellignore
+++ b/.cspellignore
@@ -29,3 +29,4 @@ schemaname
 tablename
 timestamptz
 formatjs
+cspellignore

--- a/create-app/src/scripts/create-app/addProjectNameToUserDictionary.ts
+++ b/create-app/src/scripts/create-app/addProjectNameToUserDictionary.ts
@@ -1,0 +1,14 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+
+const userDictionary = ".cspellignore";
+
+export function addProjectNameToUserDictionary(projectName: string) {
+    if (!existsSync(userDictionary)) {
+        return;
+    }
+
+    let fileContent = readFileSync(userDictionary, "utf8");
+    fileContent += `${projectName.split("-").join("\n")}\n`;
+
+    writeFileSync(userDictionary, fileContent);
+}

--- a/create-app/src/scripts/create-app/createApp.ts
+++ b/create-app/src/scripts/create-app/createApp.ts
@@ -5,6 +5,7 @@ import process from "process";
 
 import { replacePlaceholder } from "../../util/replacePlaceholder";
 import { runEslintFix } from "../../util/runEslintFix";
+import { addProjectNameToUserDictionary } from "./addProjectNameToUserDictionary";
 import { amendCommitChanges } from "./amendCommitChanges";
 import { cleanupReadme } from "./cleanupReadme";
 import { cleanupWorkingDirectory } from "./cleanupWorkingDirectory";
@@ -25,6 +26,7 @@ export async function createApp(commandOptions: CreateAppCommandOptions) {
     cleanupReadme(commandOptions.verbose);
     cleanupWorkingDirectory(commandOptions.verbose);
     replacePlaceholder(commandOptions.projectName, commandOptions.verbose);
+    addProjectNameToUserDictionary(commandOptions.projectName);
     createInitialGitCommit(commandOptions.verbose);
     if (commandOptions.install) {
         const spinner = createSpinner("Installing project...").spin();


### PR DESCRIPTION
Prevents the lint pipeline from failing when creating a new project with an "unknown" name.
