### PR TITLE
Fix broken site page for unknown language in URL

### DIFF
--- a/site/src/app/[visibility]/[domain]/[language]/[[...path]]/layout.tsx
+++ b/site/src/app/[visibility]/[domain]/[language]/[[...path]]/layout.tsx
@@ -15,6 +15,10 @@ interface LayoutProps {
 }
 
 export default async function Layout({ children, params: { domain, language } }: PropsWithChildren<LayoutProps>) {
+    const siteConfig = getSiteConfigForDomain(domain);
+    if (!siteConfig.scope.languages.includes(language)) {
+        language = "en";
+    }
     const graphqlFetch = createGraphQLFetch();
 
     const { header, footer } = await graphqlFetch<GQLLayoutQuery, GQLLayoutQueryVariables>(


### PR DESCRIPTION
Opening an URL with an unknown language leads to an runtime error in the page.


**before:**
![Screenshot 2025-03-26 at 11 22 58](https://github.com/user-attachments/assets/acce2328-e2ed-478d-9d86-03c7285771a8)



**after:**
![Screenshot 2025-03-26 at 11 22 32](https://github.com/user-attachments/assets/e25a961f-3527-4cbc-a587-d512593b7ff3)


## Further information

Ticket: https://vivid-planet.atlassian.net/browse/COM-1868
