### PR TITLE
DamFileDownload Link Support

### DIFF
--- a/site/src/documents/links/Link.tsx
+++ b/site/src/documents/links/Link.tsx
@@ -1,5 +1,5 @@
 import { gql } from "@comet/cms-site";
-import { type ExternalLinkBlockData, type InternalLinkBlockData } from "@src/blocks.generated";
+import { type DamFileDownloadLinkBlockData, type ExternalLinkBlockData, type InternalLinkBlockData } from "@src/blocks.generated";
 import { type GQLPageTreeNodeScopeInput } from "@src/graphql.generated";
 import { createGraphQLFetch } from "@src/util/graphQLClient";
 import { notFound, redirect } from "next/navigation";
@@ -43,6 +43,13 @@ export async function Link({ pageTreeNodeId }: Props): Promise<JSX.Element> {
 
         if (content.block?.type === "external") {
             const link = (content.block.props as ExternalLinkBlockData).targetUrl;
+            if (link) {
+                redirect(link);
+            }
+        }
+
+        if (content.block?.type === "damFileDownload") {
+            const link = (content.block.props as DamFileDownloadLinkBlockData).file?.fileUrl.replace("/download", "");
             if (link) {
                 redirect(link);
             }


### PR DESCRIPTION
## Description

If the damFileDownload link is opened directly, it should redirect to the asset regardless of the selection ('as a download' or 'in a new tab').
Before this change, you were redirected to a 404 page.

## Screenshots/screencasts

https://github.com/user-attachments/assets/079dcf8f-327c-47b4-8538-dac08a9698b2

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1639
