### PR TITLE
Remove no longer necessary nesting of props

### DIFF
--- a/admin/src/common/blocks/AccordionItemBlock.tsx
+++ b/admin/src/common/blocks/AccordionItemBlock.tsx
@@ -31,7 +31,8 @@ export const AccordionItemBlock = createCompositeBlock(
         blocks: {
             title: {
                 block: createCompositeBlockTextField({
-                    fieldProps: { fullWidth: true, label: <FormattedMessage id="accordionBlock.accordionItem.title" defaultMessage="Title" /> },
+                    label: <FormattedMessage id="accordionBlock.accordionItem.title" defaultMessage="Title" />,
+                    fullWidth: true,
                 }),
                 hiddenInSubroute: true,
             },

--- a/admin/src/common/blocks/CallToActionBlock.tsx
+++ b/admin/src/common/blocks/CallToActionBlock.tsx
@@ -15,13 +15,14 @@ export const CallToActionBlock = createCompositeBlock(
             },
             variant: {
                 block: createCompositeBlockSelectField<CallToActionBlockData["variant"]>({
+                    label: <FormattedMessage id="callToActionBlock.variant" defaultMessage="Variant" />,
+                    fullWidth: true,
                     defaultValue: "Contained",
                     options: [
                         { value: "Contained", label: <FormattedMessage id="callToActionBlock.variant.contained" defaultMessage="Contained" /> },
                         { value: "Outlined", label: <FormattedMessage id="callToActionBlock.variant.outlined" defaultMessage="Outlined" /> },
                         { value: "Text", label: <FormattedMessage id="callToActionBlock.variant.text" defaultMessage="Text" /> },
                     ],
-                    fieldProps: { label: <FormattedMessage id="callToActionBlock.variant" defaultMessage="Variant" />, fullWidth: true },
                 }),
             },
         },

--- a/admin/src/common/blocks/HeadingBlock.tsx
+++ b/admin/src/common/blocks/HeadingBlock.tsx
@@ -71,6 +71,8 @@ export const HeadingBlock = createCompositeBlock(
             },
             htmlTag: {
                 block: createCompositeBlockSelectField<HeadingBlockData["htmlTag"]>({
+                    label: <FormattedMessage id="headingBlock.htmlTag" defaultMessage="HTML tag" />,
+                    fullWidth: true,
                     defaultValue: "H2",
                     options: [
                         { value: "H1", label: <FormattedMessage id="headingBlock.headline1" defaultMessage="Headline 1" /> },
@@ -80,7 +82,6 @@ export const HeadingBlock = createCompositeBlock(
                         { value: "H5", label: <FormattedMessage id="headingBlock.headline5" defaultMessage="Headline 5" /> },
                         { value: "H6", label: <FormattedMessage id="headingBlock.headline6" defaultMessage="Headline 6" /> },
                     ],
-                    fieldProps: { label: <FormattedMessage id="headingBlock.htmlTag" defaultMessage="HTML tag" />, fullWidth: true },
                 }),
             },
         },

--- a/admin/src/common/blocks/MediaGalleryBlock.tsx
+++ b/admin/src/common/blocks/MediaGalleryBlock.tsx
@@ -22,12 +22,10 @@ export const MediaGalleryBlock = createCompositeBlock(
             },
             aspectRatio: {
                 block: createCompositeBlockSelectField<MediaGalleryBlockData["aspectRatio"]>({
+                    label: <FormattedMessage id="mediaGalleryBlock.mediaGallery.aspectRatio" defaultMessage="Aspect Ratio" />,
+                    fullWidth: true,
                     defaultValue: "16x9",
                     options: mediaAspectRatioOptions,
-                    fieldProps: {
-                        label: <FormattedMessage id="mediaGalleryBlock.mediaGallery.aspectRatio" defaultMessage="Aspect Ratio" />,
-                        fullWidth: true,
-                    },
                 }),
                 hiddenInSubroute: true,
             },

--- a/admin/src/common/blocks/MediaGalleryItemBlock.tsx
+++ b/admin/src/common/blocks/MediaGalleryItemBlock.tsx
@@ -13,10 +13,8 @@ export const MediaGalleryItemBlock = createCompositeBlock(
             },
             caption: {
                 block: createCompositeBlockTextField({
-                    fieldProps: {
-                        fullWidth: true,
-                        label: <FormattedMessage id="mediaGalleryBlock.mediaGalleryItem.caption" defaultMessage="Caption" />,
-                    },
+                    label: <FormattedMessage id="mediaGalleryBlock.mediaGalleryItem.caption" defaultMessage="Caption" />,
+                    fullWidth: true,
                 }),
                 hiddenInSubroute: true,
             },

--- a/admin/src/common/blocks/StandaloneCallToActionListBlock.tsx
+++ b/admin/src/common/blocks/StandaloneCallToActionListBlock.tsx
@@ -13,16 +13,14 @@ export const StandaloneCallToActionListBlock = createCompositeBlock(
             },
             alignment: {
                 block: createCompositeBlockSelectField<StandaloneCallToActionListBlockData["alignment"]>({
+                    label: <FormattedMessage id="standaloneCallToActionList.alignment" defaultMessage="Alignment" />,
+                    fullWidth: true,
                     defaultValue: "left",
                     options: [
                         { value: "left", label: <FormattedMessage id="standaloneCallToActionList.alignment.left" defaultMessage="left" /> },
                         { value: "center", label: <FormattedMessage id="standaloneCallToActionList.alignment.center" defaultMessage="center" /> },
                         { value: "right", label: <FormattedMessage id="standaloneCallToActionList.alignment.right" defaultMessage="right" /> },
                     ],
-                    fieldProps: {
-                        label: <FormattedMessage id="standaloneCallToActionList.alignment" defaultMessage="Alignment" />,
-                        fullWidth: true,
-                    },
                 }),
                 hiddenInSubroute: true,
             },

--- a/admin/src/common/blocks/StandaloneHeadingBlock.tsx
+++ b/admin/src/common/blocks/StandaloneHeadingBlock.tsx
@@ -13,12 +13,13 @@ export const StandaloneHeadingBlock = createCompositeBlock(
             },
             textAlignment: {
                 block: createCompositeBlockSelectField<StandaloneHeadingBlockData["textAlignment"]>({
+                    label: <FormattedMessage id="standaloneHeading.textAlignment" defaultMessage="Text alignment" />,
+                    fullWidth: true,
                     defaultValue: "left",
                     options: [
                         { value: "left", label: <FormattedMessage id="standaloneHeading.textAlignment.left" defaultMessage="left" /> },
                         { value: "center", label: <FormattedMessage id="standaloneHeading.textAlignment.center" defaultMessage="center" /> },
                     ],
-                    fieldProps: { label: <FormattedMessage id="standaloneHeading.textAlignment" defaultMessage="Text alignment" />, fullWidth: true },
                 }),
             },
         },

--- a/admin/src/common/blocks/StandaloneMediaBlock.tsx
+++ b/admin/src/common/blocks/StandaloneMediaBlock.tsx
@@ -14,9 +14,10 @@ export const StandaloneMediaBlock = createCompositeBlock(
             },
             aspectRatio: {
                 block: createCompositeBlockSelectField<StandaloneMediaBlockData["aspectRatio"]>({
+                    label: <FormattedMessage id="standaloneMedia.aspectRatio" defaultMessage="Aspect Ratio" />,
+                    fullWidth: true,
                     defaultValue: "16x9",
                     options: mediaAspectRatioOptions,
-                    fieldProps: { label: <FormattedMessage id="standaloneMedia.aspectRatio" defaultMessage="Aspect Ratio" />, fullWidth: true },
                 }),
             },
         },

--- a/admin/src/documents/pages/blocks/BasicStageBlock.tsx
+++ b/admin/src/documents/pages/blocks/BasicStageBlock.tsx
@@ -40,7 +40,7 @@ export const BasicStageBlock = createCompositeBlock({
             block: createCompositeBlockSelectField<BasicStageBlockData["overlay"]>({
                 defaultValue: 50,
                 options: overlayOptions,
-                fieldProps: { fullWidth: true },
+                fullWidth: true,
             }),
             title: <FormattedMessage id="basicStageBlock.overlay" defaultMessage="Overlay" />,
             hiddenInSubroute: true,
@@ -52,7 +52,7 @@ export const BasicStageBlock = createCompositeBlock({
                     { value: "left", label: <FormattedMessage id="basicStageBlock.alignment.left" defaultMessage="left" /> },
                     { value: "center", label: <FormattedMessage id="basicStageBlock.alignment.center" defaultMessage="center" /> },
                 ],
-                fieldProps: { fullWidth: true },
+                fullWidth: true,
             }),
             title: <FormattedMessage id="basicStageBlock.alignment" defaultMessage="Alignment" />,
             hiddenInSubroute: true,

--- a/admin/src/documents/pages/blocks/BillboardTeaserBlock.tsx
+++ b/admin/src/documents/pages/blocks/BillboardTeaserBlock.tsx
@@ -41,7 +41,7 @@ export const BillboardTeaserBlock = createCompositeBlock(
                 block: createCompositeBlockSelectField<BillboardTeaserBlockData["overlay"]>({
                     defaultValue: 50,
                     options: overlayOptions,
-                    fieldProps: { fullWidth: true },
+                    fullWidth: true,
                 }),
                 title: <FormattedMessage id="billboardTeaserBlock.overlay" defaultMessage="Overlay" />,
                 hiddenInSubroute: true,

--- a/admin/src/documents/pages/blocks/ContentGroupBlock.tsx
+++ b/admin/src/documents/pages/blocks/ContentGroupBlock.tsx
@@ -43,9 +43,10 @@ export const ContentGroupBlock = createCompositeBlock(
         blocks: {
             backgroundColor: {
                 block: createCompositeBlockSelectField<ContentGroupBlockData["backgroundColor"]>({
+                    label: <FormattedMessage id="contentGroupBlock.overlay" defaultMessage="Background Color" />,
+                    fullWidth: true,
                     defaultValue: "default",
                     options: backgroundColorOptions,
-                    fieldProps: { fullWidth: true, label: <FormattedMessage id="contentGroupBlock.overlay" defaultMessage="Background Color" /> },
                 }),
                 hiddenInSubroute: true,
             },

--- a/admin/src/documents/pages/blocks/KeyFactsItemBlock.tsx
+++ b/admin/src/documents/pages/blocks/KeyFactsItemBlock.tsx
@@ -22,12 +22,14 @@ export const KeyFactsItemBlock = createCompositeBlock(
             },
             fact: {
                 block: createCompositeBlockTextField({
-                    fieldProps: { fullWidth: true, label: <FormattedMessage id="keyFactsItemBlock.fact" defaultMessage="Fact" /> },
+                    label: <FormattedMessage id="keyFactsItemBlock.fact" defaultMessage="Fact" />,
+                    fullWidth: true,
                 }),
             },
             label: {
                 block: createCompositeBlockTextField({
-                    fieldProps: { fullWidth: true, label: <FormattedMessage id="keyFactsItemBlock.label" defaultMessage="Label" /> },
+                    label: <FormattedMessage id="keyFactsItemBlock.label" defaultMessage="Label" />,
+                    fullWidth: true,
                 }),
             },
             description: {

--- a/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -24,7 +24,8 @@ export const TeaserItemBlock = createCompositeBlock(
             },
             title: {
                 block: createCompositeBlockTextField({
-                    fieldProps: { fullWidth: true, label: <FormattedMessage id="teaserItemBlock.title" defaultMessage="Title" /> },
+                    label: <FormattedMessage id="teaserItemBlock.title" defaultMessage="Title" />,
+                    fullWidth: true,
                 }),
             },
             description: {

--- a/admin/src/footers/blocks/FooterContentBlock.tsx
+++ b/admin/src/footers/blocks/FooterContentBlock.tsx
@@ -23,10 +23,8 @@ export const FooterContentBlock = createCompositeBlock({
         },
         copyrightNotice: {
             block: createCompositeBlockTextField({
-                fieldProps: {
-                    label: <FormattedMessage id="footers.blocks.content.copyrightNotice" defaultMessage="Copyright notice" />,
-                    fullWidth: true,
-                },
+                label: <FormattedMessage id="footers.blocks.content.copyrightNotice" defaultMessage="Copyright notice" />,
+                fullWidth: true,
             }),
             hiddenInSubroute: true,
         },


### PR DESCRIPTION
## Description

Nesting the props inside `fieldProps` inside `createCompositeBlockTextField` and `createCompositeBlockSelectField` is no longer necessary, see: https://github.com/vivid-planet/comet/pull/3155.

## Further information 

- Task: https://vivid-planet.atlassian.net/browse/COM-1726