### PR TITLE
Use static user as long static user service is used

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -27,7 +27,7 @@ import { Request } from "express";
 
 import { AccessControlService } from "./auth/access-control.service";
 import { AuthModule, SYSTEM_USER_NAME } from "./auth/auth.module";
-import { UserService } from "./auth/user.service";
+import { StaticUsersUserService } from "./auth/static-users.user.service";
 import { Config } from "./config/config";
 import { ConfigModule } from "./config/config.module";
 import { DamFile } from "./dam/entities/dam-file.entity";
@@ -80,7 +80,7 @@ export class AppModule {
                 }),
                 authModule,
                 UserPermissionsModule.forRootAsync({
-                    useFactory: (userService: UserService, accessControlService: AccessControlService) => ({
+                    useFactory: (userService: StaticUsersUserService, accessControlService: AccessControlService) => ({
                         availableContentScopes: config.siteConfigs.flatMap((siteConfig) =>
                             siteConfig.scope.languages.map((language) => ({
                                 domain: siteConfig.scope.domain,
@@ -91,7 +91,7 @@ export class AppModule {
                         accessControlService,
                         systemUsers: [SYSTEM_USER_NAME],
                     }),
-                    inject: [UserService, AccessControlService],
+                    inject: [StaticUsersUserService, AccessControlService], // TODO Implement correct UserService and remove convertJwtToUser in AuthModule
                     imports: [authModule],
                 }),
                 BlocksModule,

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -14,7 +14,7 @@ import { Config } from "@src/config/config";
 
 import { AccessControlService } from "./access-control.service";
 import { staticUsers } from "./static-users";
-import { UserService } from "./user.service";
+import { StaticUsersUserService } from "./static-users.user.service";
 
 export const SYSTEM_USER_NAME = "system-user";
 
@@ -34,12 +34,20 @@ export class AuthModule {
                 endSessionEndpoint: config.auth.idpEndSessionEndpoint,
             }),
             AccessControlService,
-            UserService,
+            StaticUsersUserService,
         ];
 
         if (config.auth.useAuthProxy) {
             authServices.push(
-                createJwtAuthService({ verifyOptions: { audience: config.auth.idpClientId }, jwksOptions: { jwksUri: config.auth.idpJwksUri } }),
+                createJwtAuthService({
+                    verifyOptions: {
+                        audience: config.auth.idpClientId,
+                    },
+                    jwksOptions: {
+                        jwksUri: config.auth.idpJwksUri,
+                    },
+                    convertJwtToUser: () => staticUsers.vividPlanetEmployee, // TODO Remove when correct UserService is used in UserPermissionsModule
+                }),
             );
             providers.push({
                 provide: APP_GUARD,
@@ -65,7 +73,7 @@ export class AuthModule {
         return {
             module: AuthModule,
             providers,
-            exports: [AccessControlService, UserService],
+            exports: [AccessControlService, StaticUsersUserService],
             imports: [JwtModule],
         };
     }

--- a/api/src/auth/static-users.ts
+++ b/api/src/auth/static-users.ts
@@ -3,17 +3,17 @@ import { type User } from "@comet/cms-api";
 export const staticUsers = {
     vividPlanetEmployee: {
         id: "a19a100d-3bce-4b29-ad47-e6119d15923e",
-        name: "Vivid Planet Employee",
+        name: "Static User - Employee",
         email: "employee@vivid-planet.com",
     },
     admin: {
         id: "3b09cc12-c7e6-4d16-b858-40a822f2c548",
-        name: "Admin",
+        name: "Static User - Admin",
         email: "admin@customer.com",
     },
     editor: {
         id: "a0b13472-1ee5-4afc-8734-be661e60334f",
-        name: "German Editor",
+        name: "Static User - German Editor",
         email: "german-editor@customer.com",
     },
 } satisfies Record<string, User>;

--- a/api/src/auth/static-users.user.service.ts
+++ b/api/src/auth/static-users.user.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from "@nestjs/common";
 import { staticUsers } from "./static-users";
 
 @Injectable()
-export class UserService implements UserPermissionsUserServiceInterface {
+export class StaticUsersUserService implements UserPermissionsUserServiceInterface {
     getUser(id: string): User {
         const user = Object.values(staticUsers).find((user) => user.id === id);
 


### PR DESCRIPTION
https://vivid-planet.atlassian.net/browse/COM-1870

The starter implementation by default uses the `StaticUsersUserService` for the `UserPermissionsModule`. In contrary, the deployment templates (and hence our demo deployments) we provide use an Authproxy, for this reason we use `createJwtAuthService` in the `AuthService`. The problem is that the `CometAuthGuard` retrieves the authed user id from `createJwtAuthService` and then tries to load the user from the `StaticUsersUserService` which results in a mismatch.

This PR works around this problem by providing `convertJwtToUser` which blindly loads a static user as long the appropriate user service is not used.

Further changes of this PR:
- Rename `UserService` to `StaticUsersUserService`
- Change names of static users to show clearly that static users are used
- Add todos for devs what to change when implementing the correct user service