### PR TITLE
Rename API_PASSWORD env for site

### DIFF
--- a/site/src/util/graphQLClient.ts
+++ b/site/src/util/graphQLClient.ts
@@ -29,7 +29,7 @@ export function createGraphQLFetch() {
             },
             headers: {
                 "x-relative-dam-urls": "1",
-                authorization: `Basic ${Buffer.from(`vivid:${process.env.API_PASSWORD}`).toString("base64")}`,
+                authorization: `Basic ${Buffer.from(`vivid:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
                 ...convertPreviewDataToHeaders(previewData),
             },
         }),


### PR DESCRIPTION
See https://github.com/vivid-planet/comet/pull/3748. This is also part of the reason, why currently the deployment on DigtialOcean is not working.
