### PR TITLE
Add missing media-src to CSP

### DIFF
--- a/admin/server/index.js
+++ b/admin/server/index.js
@@ -30,6 +30,7 @@ app.use(
                 "font-src": ["'self'", "data:"],
                 "connect-src": ["'self'"],
                 "img-src": ["'self'", "data:"],
+                "media-src": ["'self'", "data:"],
                 "frame-src": [process.env.PREVIEW_URL],
                 upgradeInsecureRequests: process.env.NODE_ENV === "development" ? undefined : [], // Upgrade all requests to HTTPS on production
             },

--- a/site/src/middleware/contentSecurityPolicyHeaders.ts
+++ b/site/src/middleware/contentSecurityPolicyHeaders.ts
@@ -11,7 +11,8 @@ const contentSecurityPolicyDirectives: ContentSecurityPolicyDirective[] = [
     { directive: "default-src", values: ["'none'"] }, // Restrict any content not explicitly allowed
     { directive: "style-src-elem", values: ["'self'", "'unsafe-inline'"] },
     { directive: "script-src-elem", values: ["'self'", "'unsafe-inline'"] },
-    { directive: "img-src", values: ["'self'", "data:", process.env.API_URL?.replace("/api", "") ?? ""] },
+    { directive: "img-src", values: ["'self'", "data:"] },
+    { directive: "media-src", values: ["'self'", "data:"] },
     { directive: "style-src-attr", values: ["'unsafe-inline'"] },
     { directive: "font-src", values: ["'self'", "data:"] },
     { directive: "frame-ancestors", values: [process.env.ADMIN_URL ?? "https:"] },


### PR DESCRIPTION
Videos couldn't be played in site and admin because a media-src CSP was missing. It is already present in Demo.

Furthermore, the API_URL is removed from img-src because all images and videos are now delivered under the site URL

<img width="1728" alt="Bildschirmfoto 2025-04-14 um 15 31 48" src="https://github.com/user-attachments/assets/acd43189-59e9-47e5-a36c-334312bd278b" />
