### PR TITLE
Add YouTube and Vimeo Domains to frame-src CSP

### DIFF
--- a/site/src/common/blocks/MediaBlock.tsx
+++ b/site/src/common/blocks/MediaBlock.tsx
@@ -4,6 +4,7 @@ import {
     PreviewSkeleton,
     type PropsWithData,
     type SupportedBlocks,
+    VimeoVideoBlock,
     withPreview,
     YouTubeVideoBlock,
 } from "@comet/cms-site";
@@ -15,6 +16,7 @@ const getSupportedBlocks = (sizes: string, aspectRatio: string, fill?: boolean):
         image: (data) => <DamImageBlock data={data} sizes={sizes} aspectRatio={aspectRatio} fill={fill} />,
         damVideo: (data) => <DamVideoBlock data={data} previewImageSizes={sizes} aspectRatio={aspectRatio} fill={fill} />,
         youTubeVideo: (data) => <YouTubeVideoBlock data={data} previewImageSizes={sizes} aspectRatio={aspectRatio} fill={fill} />,
+        vimeoVideo: (data) => <VimeoVideoBlock data={data} previewImageSizes={sizes} aspectRatio={aspectRatio} fill={fill} />,
     };
 };
 

--- a/site/src/middleware/contentSecurityPolicyHeaders.ts
+++ b/site/src/middleware/contentSecurityPolicyHeaders.ts
@@ -15,6 +15,7 @@ const contentSecurityPolicyDirectives: ContentSecurityPolicyDirective[] = [
     { directive: "style-src-attr", values: ["'unsafe-inline'"] },
     { directive: "font-src", values: ["'self'", "data:"] },
     { directive: "frame-ancestors", values: [process.env.ADMIN_URL ?? "https:"] },
+    { directive: "frame-src", values: ["https://*.youtube-nocookie.com", "https://player.vimeo.com"] },
 ];
 
 if (process.env.NODE_ENV === "development") {


### PR DESCRIPTION
Since we support the YouTubeVideoBlock and the VimeoVideoBlock per default, we should also allow the Domains in the CSP

(also add the VimeoVideoBlock to the site. Apparently it was only defined in API and Admin till now)

--- 

Demo PR: https://github.com/vivid-planet/comet/pull/3793