### PR TITLE
Add aria-hidden to SvgUse component to hide SVGs by default

### DIFF
--- a/site/src/common/helpers/SvgUse.tsx
+++ b/site/src/common/helpers/SvgUse.tsx
@@ -6,7 +6,7 @@ interface SvgUseProps extends SVGProps<SVGSVGElement> {
 }
 
 export const SvgUse = ({ href, ...props }: SvgUseProps) => (
-    <svg {...props}>
+    <svg aria-hidden="true" {...props}>
         <use href={href} xlinkHref={href} />
     </svg>
 );


### PR DESCRIPTION
## Description

Decorative elements and non-interactive content (such as icons) should not be exposed to accessibility APIs. The aria-hidden attribute ensures these elements are excluded from the accessibility tree.

However, since some elements may still be relevant, this attribute can be overridden when necessary.

## Screenshots/screencasts

https://github.com/user-attachments/assets/053afdba-2cb2-48fc-aeaf-4e69e25bf153

## Related tasks and documents

- Task: https://vivid-planet.atlassian.net/browse/COM-1713
- PR in Demo: https://github.com/vivid-planet/comet/pull/3797
