### PR TITLE
Fix TRACING_ENABLED check

### DIFF
--- a/api/src/console.ts
+++ b/api/src/console.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let tracing: any;
-if (process.env.TRACING_ENABLED) {
+if (process.env.TRACING_ENABLED === "1") {
     tracing = import("./tracing");
 }
 

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -1,4 +1,4 @@
-if (process.env.TRACING_ENABLED) {
+if (process.env.TRACING_ENABLED === "1") {
     import("./tracing");
 }
 

--- a/site/server.ts
+++ b/site/server.ts
@@ -12,7 +12,7 @@ const app = next({ dev, hostname: host, port });
 const handle = app.getRequestHandler();
 
 app.prepare().then(() => {
-    if (process.env.TRACING_ENABLED) {
+    if (process.env.TRACING_ENABLED === "1") {
         require("./tracing");
     }
     createServer(async (req, res) => {


### PR DESCRIPTION
## Description

Using a truthy check will never return false for any string, even `"false"`.

## Further information

I didn't change this in Demo first since Demo doesn't have a tracing setup (yet).
