### PR TITLE
Add 1200x630 to allowed aspect ratios

### DIFF
--- a/api/src/comet-config.json
+++ b/api/src/comet-config.json
@@ -1,6 +1,6 @@
 {
     "dam": {
-        "allowedImageAspectRatios": ["16x9", "4x3", "3x2", "3x1", "2x1", "1x1", "1x2", "1x3", "2x3", "3x4", "9x16"],
+        "allowedImageAspectRatios": ["16x9", "4x3", "3x2", "3x1", "2x1", "1x1", "1x2", "1x3", "2x3", "3x4", "9x16", "1200x630"],
         "uploadsMaxFileSize": 500
     },
     "images": {


### PR DESCRIPTION
As done here in Demo: https://github.com/vivid-planet/comet/pull/2062/files#diff-bb62086b1bdcdc241c952ff819e5915c6abd367710e871998eafc5768312a3a2R13

### Why?

We use 1200 x 630 for og images (see https://github.com/vivid-planet/comet-starter/blob/a13ac48cd35fada990c361f0b3c0b90a181d2cfa/site/src/documents/pages/Page.tsx#L78). Currently this is broken in starter because the aspect ratio is not allowed