### PR TITLE
CSP: Allow images in block preview

### DIFF
--- a/site/src/middleware/contentSecurityPolicyHeaders.ts
+++ b/site/src/middleware/contentSecurityPolicyHeaders.ts
@@ -4,14 +4,14 @@ import { type CustomMiddleware } from "./chain";
 
 type ContentSecurityPolicyDirective = {
     directive: string;
-    values: string[];
+    values: Array<string | undefined>;
 };
 
 const contentSecurityPolicyDirectives: ContentSecurityPolicyDirective[] = [
     { directive: "default-src", values: ["'none'"] }, // Restrict any content not explicitly allowed
     { directive: "style-src-elem", values: ["'self'", "'unsafe-inline'"] },
     { directive: "script-src-elem", values: ["'self'", "'unsafe-inline'"] },
-    { directive: "img-src", values: ["'self'", "data:"] },
+    { directive: "img-src", values: ["'self'", "data:", process.env.ADMIN_URL] },
     { directive: "media-src", values: ["'self'", "data:"] },
     { directive: "style-src-attr", values: ["'unsafe-inline'"] },
     { directive: "font-src", values: ["'self'", "data:"] },
@@ -26,7 +26,9 @@ if (process.env.NODE_ENV === "development") {
     contentSecurityPolicyDirectives.push({ directive: "upgrade-insecure-requests", values: [] });
 }
 
-const contentSecurityPolicy = contentSecurityPolicyDirectives.map((directive) => `${directive.directive} ${directive.values.join(" ")}`).join("; ");
+const contentSecurityPolicy = contentSecurityPolicyDirectives
+    .map((directive) => `${directive.directive} ${directive.values.filter((value) => value !== undefined).join(" ")}`)
+    .join("; ");
 
 export function withContentSecurityPolicyHeadersMiddleware(middleware: CustomMiddleware) {
     return async (request: NextRequest) => {


### PR DESCRIPTION
## Description

Now that we [proxy API-requests through the Admin Domain ](https://github.com/vivid-planet/comet-starter/pull/787), we need to allow images from the Admin domain for the block preview to work correctly.