### PR TITLE
`AccordionBlock`: prevent collapsed content to receive focus

### DIFF
--- a/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/site/src/common/blocks/AccordionItemBlock.tsx
@@ -88,13 +88,18 @@ const ContentWrapper = styled.div<{ $isExpanded: boolean }>`
     position: relative;
     display: grid;
     grid-template-rows: 0fr;
-    transition: grid-template-rows 0.5s ease-out;
+    transition:
+        grid-template-rows 0.5s ease-out,
+        visibility 0s linear 0.5s;
+    visibility: hidden;
 
     ${({ $isExpanded }) =>
         $isExpanded &&
         css`
             grid-template-rows: 1fr;
             padding-bottom: ${({ theme }) => theme.spacing.S300};
+            visibility: visible;
+            transition-delay: 0s;
         `}
 `;
 


### PR DESCRIPTION
## Description

When focusable elements are in the accordions content, they are focusable even when the accordion is collapsed. visibility: hidden; prevents the content from receiving focus.

## Further information

https://github.com/vivid-planet/comet/pull/3879 for Starter.