### PR TITLE
AccordionItemBlock: remove obsolete aria-hidden attribute

### DIFF
--- a/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/site/src/common/blocks/AccordionItemBlock.tsx
@@ -45,7 +45,7 @@ export const AccordionItemBlock = withPreview(
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#root" $isExpanded={isExpanded} />
                     </IconWrapper>
                 </TitleWrapper>
-                <ContentWrapper aria-hidden={!isExpanded} $isExpanded={isExpanded}>
+                <ContentWrapper $isExpanded={isExpanded}>
                     <ContentWrapperInner>
                         <AccordionContentBlock data={content} />
                     </ContentWrapperInner>


### PR DESCRIPTION
## Description

The aria-hidden attribute is not needed, when visibility is set to none:

https://developer.mozilla.org/en-US/docs/Web/CSS/visibility#accessibility 

(Thank you @stekalt 🫶 )

## Further information

https://github.com/vivid-planet/comet/pull/3886 for Starter.