### PR TITLE
Renovate: ignore canary Comet releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
             "groupName": "comet",
             "prPriority": 6,
             "matchPackageNames": ["/@comet/*/"],
-            "labels": ["comet", "dependencies"]
+            "labels": ["comet", "dependencies"],
+            "allowedVersions": "!/canary/"
         },
         {
             "groupName": "eslint",


### PR DESCRIPTION
## Description

Renovate tries to update Comet to the latest canary release once we enter the beta stage (see the [ignoreUnstable](https://docs.renovatebot.com/configuration-options/#ignoreunstable) option). We fix this by excluding canary releases using the [allowedVersions](https://docs.renovatebot.com/configuration-options/#ignore-versions-with-negated-regex-syntax) option.