### PR TITLE
Add createImageSizes helper

### DIFF
--- a/site/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/site/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -5,6 +5,7 @@ import { MediaBlock } from "@src/common/blocks/MediaBlock";
 import { defaultRichTextInlineStyleMap, RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { Typography } from "@src/common/components/Typography";
 import { SvgUse } from "@src/common/helpers/SvgUse";
+import { createImageSizes } from "@src/util/createImageSizes";
 import { type Renderers } from "redraft";
 import styled from "styled-components";
 
@@ -16,10 +17,10 @@ export const TeaserItemBlock = withPreview(
     ({ data: { media, title, description, link } }: PropsWithData<TeaserItemBlockData>) => (
         <RootLinkBlock data={link.link}>
             <MediaMobile>
-                <MediaBlock data={media} aspectRatio="1x1" sizes="20vw" />
+                <MediaBlock data={media} aspectRatio="1x1" sizes={createImageSizes({ default: "20vw" })} />
             </MediaMobile>
             <MediaDesktop>
-                <MediaBlock data={media} aspectRatio="16x9" sizes="20vw" />
+                <MediaBlock data={media} aspectRatio="16x9" sizes={createImageSizes({ default: "20vw" })} />
             </MediaDesktop>
             <ContentContainer>
                 <TitleTypography variant="h350">{title}</TitleTypography>

--- a/site/src/theme.ts
+++ b/site/src/theme.ts
@@ -52,7 +52,7 @@ export const theme = {
     },
 };
 
-type Theme = typeof theme;
+export type Theme = typeof theme;
 
 declare module "styled-components" {
     // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/site/src/util/createImageSizes.ts
+++ b/site/src/util/createImageSizes.ts
@@ -1,0 +1,22 @@
+import { type Theme, theme } from "@src/theme";
+
+type BreakpointWidths = { default: string | number } & Partial<Record<keyof Theme["breakpoints"], string | number>>;
+
+export function createImageSizes(breakpointWidths: BreakpointWidths) {
+    const sizes: string[] = [];
+    const breakpoints = Object.entries(theme.breakpoints).sort((a, b) => b[1].value - a[1].value); // breakpoint values have to be sorted in descending order when using min-width in the sizes property
+    const defaultSize = breakpointWidths.default;
+
+    breakpoints.forEach(([breakpointKey, breakpointValue]) => {
+        const size = breakpointWidths[breakpointKey as keyof BreakpointWidths];
+        const minWidth = breakpointValue.value;
+
+        if (size !== undefined) {
+            sizes.push(`(min-width: ${minWidth}px) ${typeof size === "string" ? size : `${size}px`}`);
+        }
+    });
+
+    sizes.push(`${typeof defaultSize === "string" ? defaultSize : `${defaultSize}px`}`);
+
+    return sizes.join(", ");
+}


### PR DESCRIPTION
## Description

The function `createImageSizes` is implemented to generate the `sizes` attribute string for Next.js images based on the breakpoints in the project. The `sizes` attribute is used by the browser to decide which image from the `srcset` to load depending on the viewport width.

## Screenshots/screencasts

https://github.com/user-attachments/assets/2661fa90-83dc-44a0-95e0-eb0c289df963

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-2150

## Further information

https://nextjs.org/docs/pages/api-reference/components/image#sizes