### PR TITLE
Set fields to required in HeadingBlock in admin

### DIFF
--- a/admin/src/common/blocks/HeadingBlock.tsx
+++ b/admin/src/common/blocks/HeadingBlock.tsx
@@ -82,6 +82,7 @@ export const HeadingBlock = createCompositeBlock(
                         { value: "h5", label: <FormattedMessage id="headingBlock.headline5" defaultMessage="Headline 5" /> },
                         { value: "h6", label: <FormattedMessage id="headingBlock.headline6" defaultMessage="Headline 6" /> },
                     ],
+                    required: true,
                 }),
             },
         },

--- a/admin/src/common/blocks/StandaloneHeadingBlock.tsx
+++ b/admin/src/common/blocks/StandaloneHeadingBlock.tsx
@@ -20,6 +20,7 @@ export const StandaloneHeadingBlock = createCompositeBlock(
                         { value: "left", label: <FormattedMessage id="standaloneHeading.textAlignment.left" defaultMessage="left" /> },
                         { value: "center", label: <FormattedMessage id="standaloneHeading.textAlignment.center" defaultMessage="center" /> },
                     ],
+                    required: true,
                 }),
             },
         },


### PR DESCRIPTION
## Description

Problem: `htmlTag` (in HeadlineBlock) and `textAlignment` (in StandaloneHeadlineBlock) are required fields, but the Select field is clearable. --> set fields to required


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="534" height="622" alt="Screenshot 2025-07-23 at 14 57 40" src="https://github.com/user-attachments/assets/65ff85a6-33f7-4e02-8730-e8027395383a" /> |  <img width="542" height="605" alt="Screenshot 2025-07-23 at 14 55 22" src="https://github.com/user-attachments/assets/fcfa5679-d95c-44a7-86bc-d8b85429c80e" /> 

## Open TODOs/questions

-   [x] Add changeset
-  [x] Add  Comet Demo PR: https://github.com/vivid-planet/comet/pull/4216

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2172
