### PR TITLE
Fix structure of `LinkList` in `Footer`

### DIFF
--- a/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -130,6 +130,8 @@ const LinksWrapper = styled.ul`
     flex-wrap: wrap;
     justify-content: center;
     list-style: none;
+    margin: 0;
+    padding: 0;
 `;
 
 const CopyrightNotice = styled(Typography)`

--- a/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -23,15 +23,19 @@ export const FooterContentBlock = withPreview(
                         </TopContainer>
                         <HorizontalLine />
                         <LinkCopyrightWrapper>
-                            {linkList.blocks.length > 0 && (
-                                <LinksWrapper>
-                                    {linkList.blocks.map((block) => (
-                                        <LinkText key={block.key} as={LinkBlock} data={block.props.link} variant="p200">
-                                            {block.props.text}
-                                        </LinkText>
-                                    ))}
-                                </LinksWrapper>
-                            )}
+                            <nav>
+                                {linkList.blocks.length > 0 && (
+                                    <LinksWrapper>
+                                        {linkList.blocks.map((block) => (
+                                            <li key={block.key}>
+                                                <LinkText as={LinkBlock} data={block.props.link} variant="p200">
+                                                    {block.props.text}
+                                                </LinkText>
+                                            </li>
+                                        ))}
+                                    </LinksWrapper>
+                                )}
+                            </nav>
                             {copyrightNotice && <CopyrightNotice variant="p200">{copyrightNotice}</CopyrightNotice>}
                         </LinkCopyrightWrapper>
                     </PageLayoutContent>
@@ -120,11 +124,12 @@ const LinkCopyrightWrapper = styled.div`
     }
 `;
 
-const LinksWrapper = styled.div`
+const LinksWrapper = styled.ul`
     display: flex;
     gap: ${({ theme }) => theme.spacing.s500};
     flex-wrap: wrap;
     justify-content: center;
+    list-style: none;
 `;
 
 const CopyrightNotice = styled(Typography)`


### PR DESCRIPTION
## Description

At the moment the links of the `LinkList`in the `Footer` are only nested in divs. This is semantically incorrect -> fix structure of LinkList by adding `<nav>`, `<ul>`, and `<li>` tags.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [a changeset](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#changeset)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="576" height="120" alt="Screenshot 2025-07-24 at 14 49 06" src="https://github.com/user-attachments/assets/ffe82624-8f72-4580-95c5-88eca18447aa" /> <img width="1919" height="400" alt="Screenshot 2025-07-24 at 14 49 42" src="https://github.com/user-attachments/assets/80e6ee71-80d2-4fb9-9686-f8bf3c045385" />| <img width="589" height="220" alt="Screenshot 2025-07-24 at 14 46 14" src="https://github.com/user-attachments/assets/6fccac90-e76f-402c-b3e6-7209534ef597" /> <img width="1919" height="468" alt="Screenshot 2025-07-24 at 14 49 51" src="https://github.com/user-attachments/assets/d8a5e7ca-ec8c-4bbc-a374-107a3b1d5c19" />

## Open TODOs/questions

-   [x] Add changeset
-  [x] PR in Demo: https://github.com/vivid-planet/comet/pull/4217

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2176
