### PR TITLE
Add missing Date-Scalars to admin/codegen.ts

### DIFF
--- a/admin/codegen.ts
+++ b/admin/codegen.ts
@@ -26,7 +26,7 @@ const config: CodegenConfig = {
                 },
                 enumsAsTypes: true,
                 namingConvention: "keep",
-                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), { DateTime: "string" }),
+                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), { DateTime: "string", Date: "string", LocalDate: "string" }),
                 typesPrefix: "GQL",
             },
         },
@@ -43,7 +43,7 @@ const config: CodegenConfig = {
                 },
                 enumsAsTypes: true,
                 namingConvention: "keep",
-                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), { DateTime: "string" }),
+                scalars: rootBlocks.reduce((scalars, rootBlock) => ({ ...scalars, [rootBlock]: rootBlock }), { DateTime: "string", Date: "string", LocalDate: "string" }),
                 typesPrefix: "GQL",
                 skipDocumentsValidation: {
                     ignoreRules: ["KnownFragmentNamesRule"],


### PR DESCRIPTION
## Description
graphql.generated.ts types for Scalars["DateTime"], Scalars["Date"] and Scalars["LocalDate"] are now similarly generated with type `string` and not `any`.
This fixes issues with admin-generator grid-config (is already done in comet/demo: https://github.com/vivid-planet/comet/pull/4056), and probably some other cases.


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Open TODOs/questions

-   [ ] 

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-XXX
