### PR TITLE
A11Y: Add FocusTrap to Menu in Header

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -19,6 +19,7 @@
                 "next": "^14.2.30",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
+                "react-focus-lock": "^2.13.6",
                 "react-intl": "^6.8.9",
                 "redraft": "^0.10.2",
                 "styled-components": "^6.1.19",
@@ -863,7 +864,6 @@
             "version": "7.27.6",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
             "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -8808,6 +8808,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/detect-node-es": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+            "license": "MIT"
+        },
         "node_modules/diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -10128,6 +10134,18 @@
             "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/focus-lock": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+            "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.3"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/for-each": {
             "version": "0.3.5",
@@ -12991,7 +13009,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -13875,7 +13892,6 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.4.0",
@@ -13949,6 +13965,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-clientside-effect": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
+            "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.13"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            }
+        },
         "node_modules/react-dom": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -13960,6 +13988,29 @@
             },
             "peerDependencies": {
                 "react": "^18.3.1"
+            }
+        },
+        "node_modules/react-focus-lock": {
+            "version": "2.13.6",
+            "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.6.tgz",
+            "integrity": "sha512-ehylFFWyYtBKXjAO9+3v8d0i+cnc1trGS0vlTGhzFW1vbFXVUTmR8s2tt/ZQG8x5hElg6rhENlLG1H3EZK0Llg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "focus-lock": "^1.3.6",
+                "prop-types": "^15.6.2",
+                "react-clientside-effect": "^1.2.7",
+                "use-callback-ref": "^1.3.3",
+                "use-sidecar": "^1.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-intl": {
@@ -16187,6 +16238,49 @@
             "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/use-callback-ref": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+            "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-sidecar": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+            "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+            "license": "MIT",
+            "dependencies": {
+                "detect-node-es": "^1.1.0",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/usehooks-ts": {
             "version": "3.1.1",

--- a/site/package.json
+++ b/site/package.json
@@ -35,6 +35,7 @@
         "next": "^14.2.30",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-focus-lock": "^2.13.6",
         "react-intl": "^6.8.9",
         "redraft": "^0.10.2",
         "styled-components": "^6.1.19",

--- a/site/src/layout/header/MobileMenu.tsx
+++ b/site/src/layout/header/MobileMenu.tsx
@@ -3,7 +3,9 @@ import { SvgUse } from "@src/common/helpers/SvgUse";
 import { PageLink } from "@src/layout/header/PageLink";
 import { PageLayout } from "@src/layout/PageLayout";
 import { DisableBodyScrolling } from "@src/util/DisableBodyScrolling";
-import { useEffect, useState } from "react";
+import { useEscapeKeyPressed } from "@src/util/useEscapeKeyPressed";
+import { useState } from "react";
+import FocusLock from "react-focus-lock";
 import { FormattedMessage, useIntl } from "react-intl";
 import styled, { css } from "styled-components";
 
@@ -35,18 +37,13 @@ export const MobileMenu = ({ header }: Props) => {
         }
     };
 
-    useEffect(() => {
-        if (!expandedSubLevelNavigation) return;
-
-        const handleKeyDown = (event: KeyboardEvent) => {
-            if (event.key === "Escape") {
-                event.preventDefault();
-                setExpandedSubLevelNavigation(null);
-            }
-        };
-        document.addEventListener("keydown", handleKeyDown);
-        return () => document.removeEventListener("keydown", handleKeyDown);
-    }, [expandedSubLevelNavigation]);
+    useEscapeKeyPressed(() => {
+        if (expandedSubLevelNavigation !== null) {
+            setExpandedSubLevelNavigation(null);
+        } else {
+            setIsMenuOpen(false);
+        }
+    });
 
     return (
         <Root>
@@ -69,71 +66,91 @@ export const MobileMenu = ({ header }: Props) => {
             <MenuContainer $isMenuOpen={isMenuOpen} aria-hidden={!isMenuOpen}>
                 <PageLayout grid>
                     <PageLayoutContent>
-                        <TopLevelNavigation>
-                            {header.map((node) => {
-                                const visibleChildNodes = node.childNodes.filter((node) => !node.hideInMenu);
-                                return (
-                                    <li key={node.id}>
-                                        {visibleChildNodes.length > 0 ? (
-                                            <ButtonLink
-                                                aria-label={intl.formatMessage(
-                                                    {
-                                                        id: "header.subMenu.arialLabel",
-                                                        defaultMessage: "Submenu of {name}",
-                                                    },
-                                                    { name: node.name },
-                                                )}
-                                                aria-expanded={expandedSubLevelNavigation === node.id}
-                                                onClick={() => handleSubLevelNavigationButtonClick(node.id)}
-                                            >
-                                                {node.name}
-                                                <SvgUse href="/assets/icons/arrow-right.svg#root" width={16} height={16} color="inherit" />
-                                            </ButtonLink>
-                                        ) : (
-                                            <Link page={node}>{node.name}</Link>
-                                        )}
-                                        {visibleChildNodes.length > 0 && (
-                                            <SubLevelNavigation $isExpanded={expandedSubLevelNavigation === node.id}>
-                                                <PageLayout grid>
-                                                    <PageLayoutContent>
-                                                        <li>
-                                                            <BackButton onClick={() => setExpandedSubLevelNavigation(null)}>
-                                                                <SvgUse
-                                                                    href="/assets/icons/arrow-left.svg#root"
-                                                                    width={16}
-                                                                    height={16}
-                                                                    color="inherit"
-                                                                />
+                        <FocusLock>
+                            <TopLevelNavigation>
+                                <li>
+                                    <BackButton
+                                        aria-label={intl.formatMessage({
+                                            id: "header.closeButton.arialLabel",
+                                            defaultMessage: "Close Menu",
+                                        })}
+                                        onClick={() => setIsMenuOpen(false)}
+                                    >
+                                        <SvgUse href="/assets/icons/arrow-left.svg#root" width={16} height={16} color="inherit" />
+                                        <FormattedMessage id="header.closeMenu" defaultMessage="Close Menu" />
+                                    </BackButton>
+                                </li>
+                                {header.map((node) => {
+                                    const visibleChildNodes = node.childNodes.filter((node) => !node.hideInMenu);
+                                    return (
+                                        <li key={node.id}>
+                                            {visibleChildNodes.length > 0 ? (
+                                                <ButtonLink
+                                                    aria-label={intl.formatMessage(
+                                                        {
+                                                            id: "header.subMenu.arialLabel",
+                                                            defaultMessage: "Submenu of {name}",
+                                                        },
+                                                        { name: node.name },
+                                                    )}
+                                                    aria-expanded={expandedSubLevelNavigation === node.id}
+                                                    onClick={() => handleSubLevelNavigationButtonClick(node.id)}
+                                                >
+                                                    {node.name}
+                                                    <SvgUse href="/assets/icons/arrow-right.svg#root" width={16} height={16} color="inherit" />
+                                                </ButtonLink>
+                                            ) : (
+                                                <Link page={node}>{node.name}</Link>
+                                            )}
+                                            {visibleChildNodes.length > 0 && (
+                                                <SubLevelNavigation $isExpanded={expandedSubLevelNavigation === node.id}>
+                                                    <PageLayout grid>
+                                                        <PageLayoutContent>
+                                                            <li>
+                                                                <BackButton
+                                                                    aria-label={intl.formatMessage({
+                                                                        id: "header.backButton.arialLabel",
+                                                                        defaultMessage: "Go back",
+                                                                    })}
+                                                                    onClick={() => setExpandedSubLevelNavigation(null)}
+                                                                >
+                                                                    <SvgUse
+                                                                        href="/assets/icons/arrow-left.svg#root"
+                                                                        width={16}
+                                                                        height={16}
+                                                                        color="inherit"
+                                                                    />
 
-                                                                <FormattedMessage id="header.back" defaultMessage="Back" />
-                                                            </BackButton>
-                                                        </li>
-                                                        <li>
-                                                            <OverviewButton page={node}>
-                                                                <SvgUse
-                                                                    href="/assets/icons/overview.svg#root"
-                                                                    width={16}
-                                                                    height={16}
-                                                                    color="inherit"
-                                                                />
-                                                                <FormattedMessage id="header.overview" defaultMessage="Overview" />
-                                                                <span aria-hidden="true"> | </span>
-                                                                {node.name}
-                                                            </OverviewButton>
-                                                        </li>
-                                                        {visibleChildNodes.map((node) => (
-                                                            <li key={node.id}>
-                                                                <Link page={node}>{node.name}</Link>
+                                                                    <FormattedMessage id="header.back" defaultMessage="Back" />
+                                                                </BackButton>
                                                             </li>
-                                                        ))}
-                                                    </PageLayoutContent>
-                                                </PageLayout>
-                                            </SubLevelNavigation>
-                                        )}
-                                    </li>
-                                );
-                            })}
-                        </TopLevelNavigation>
+                                                            <li>
+                                                                <OverviewButton page={node}>
+                                                                    <SvgUse
+                                                                        href="/assets/icons/overview.svg#root"
+                                                                        width={16}
+                                                                        height={16}
+                                                                        color="inherit"
+                                                                    />
+                                                                    <FormattedMessage id="header.overview" defaultMessage="Overview" />
+                                                                    <span aria-hidden="true"> | </span>
+                                                                    {node.name}
+                                                                </OverviewButton>
+                                                            </li>
+                                                            {visibleChildNodes.map((node) => (
+                                                                <li key={node.id}>
+                                                                    <Link page={node}>{node.name}</Link>
+                                                                </li>
+                                                            ))}
+                                                        </PageLayoutContent>
+                                                    </PageLayout>
+                                                </SubLevelNavigation>
+                                            )}
+                                        </li>
+                                    );
+                                })}
+                            </TopLevelNavigation>
+                        </FocusLock>
                     </PageLayoutContent>
                 </PageLayout>
             </MenuContainer>

--- a/site/src/layout/header/MobileMenu.tsx
+++ b/site/src/layout/header/MobileMenu.tsx
@@ -249,6 +249,7 @@ const ButtonLinkBase = styled.button`
     width: 100%;
     padding: ${({ theme }) => theme.spacing.s500} 0;
     gap: ${({ theme }) => theme.spacing.s200};
+    font-family: ${({ theme }) => theme.fontFamily};
 
     ${({ theme }) => theme.breakpoints.sm.mediaQuery} {
         &:hover {

--- a/site/src/util/useEscapeKeyPressed.ts
+++ b/site/src/util/useEscapeKeyPressed.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+export const useEscapeKeyPressed = (keyPressed: () => void) => {
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") keyPressed();
+        };
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => {
+            window.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [keyPressed]);
+};


### PR DESCRIPTION
## Description

- Install react-focus-lock package
- Add focus trap to Submenu
- Add Close Icon to Submenu on focus, to enable closing the submenu additionally to pressing the escape button


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts








## Open TODOs/questions
[ ] PR in comet demo


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2175
