### PR TITLE
AccordionItemBlock A11y improvements

### DIFF
--- a/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/site/src/common/blocks/AccordionItemBlock.tsx
@@ -32,16 +32,17 @@ type AccordionItemBlockProps = PropsWithData<AccordionItemBlockData> & {
 export const AccordionItemBlock = withPreview(
     ({ data: { title, content }, isExpanded, onChange }: AccordionItemBlockProps) => {
         const headlineId = useId();
+        const contentId = useId();
 
         return (
             <>
-                <TitleWrapper onClick={() => onChange()} aria-label={title}>
+                <TitleWrapper onClick={() => onChange()} aria-label={title} aria-expanded={isExpanded} aria-controls={contentId}>
                     <Typography variant="h350">{title}</Typography>
                     <IconWrapper>
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#root" $isExpanded={isExpanded} />
                     </IconWrapper>
                 </TitleWrapper>
-                <ContentWrapper $isExpanded={isExpanded} role="region" aria-labelledby={headlineId}>
+                <ContentWrapper id={contentId} $isExpanded={isExpanded} role="region" aria-labelledby={headlineId}>
                     <ContentWrapperInner>
                         <AccordionContentBlock data={content} />
                     </ContentWrapperInner>

--- a/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/site/src/common/blocks/AccordionItemBlock.tsx
@@ -5,7 +5,7 @@ import { SpaceBlock } from "@src/common/blocks/SpaceBlock";
 import { StandaloneCallToActionListBlock } from "@src/common/blocks/StandaloneCallToActionListBlock";
 import { StandaloneHeadingBlock } from "@src/common/blocks/StandaloneHeadingBlock";
 import { SvgUse } from "@src/common/helpers/SvgUse";
-import { useIntl } from "react-intl";
+import { useId } from "react";
 import styled, { css } from "styled-components";
 
 import { Typography } from "../components/Typography";
@@ -31,21 +31,17 @@ type AccordionItemBlockProps = PropsWithData<AccordionItemBlockData> & {
 
 export const AccordionItemBlock = withPreview(
     ({ data: { title, content }, isExpanded, onChange }: AccordionItemBlockProps) => {
-        const intl = useIntl();
-
-        const ariaLabelText = isExpanded
-            ? intl.formatMessage({ id: "accordionBlock.ariaLabel.expanded", defaultMessage: "Collapse accordion item" })
-            : intl.formatMessage({ id: "accordionBlock.ariaLabel.collapsed", defaultMessage: "Expand accordion item" });
+        const headlineId = useId();
 
         return (
             <>
-                <TitleWrapper onClick={() => onChange()} aria-label={ariaLabelText}>
+                <TitleWrapper onClick={() => onChange()} aria-label={title}>
                     <Typography variant="h350">{title}</Typography>
                     <IconWrapper>
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#root" $isExpanded={isExpanded} />
                     </IconWrapper>
                 </TitleWrapper>
-                <ContentWrapper $isExpanded={isExpanded}>
+                <ContentWrapper $isExpanded={isExpanded} aria-labelledby={headlineId}>
                     <ContentWrapperInner>
                         <AccordionContentBlock data={content} />
                     </ContentWrapperInner>

--- a/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/site/src/common/blocks/AccordionItemBlock.tsx
@@ -41,7 +41,7 @@ export const AccordionItemBlock = withPreview(
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#root" $isExpanded={isExpanded} />
                     </IconWrapper>
                 </TitleWrapper>
-                <ContentWrapper $isExpanded={isExpanded} aria-labelledby={headlineId}>
+                <ContentWrapper $isExpanded={isExpanded} role="region" aria-labelledby={headlineId}>
                     <ContentWrapperInner>
                         <AccordionContentBlock data={content} />
                     </ContentWrapperInner>


### PR DESCRIPTION
## Description

A11y improvements for AccordionItemBlock

- use the title as description
- set aria-expanded on the button
- set aria-controls on the button
- set role region on the content
- set aria-labelledby on the content

## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)


## Further information

- Implements changes from demo: https://github.com/vivid-planet/comet/pull/3914
-   Task: https://vivid-planet.atlassian.net/browse/COM-2170
