### PR TITLE
Site: fix broken NODE_OPTIONS for dev script

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "scripts": {
         "build": "npm run intl:compile && run-p gql:types generate-block-types && tsc --project tsconfig.server.json && next build",
-        "dev": "npm run intl:compile && run-s gql:types generate-block-types && tsc --project tsconfig.server.json && NODE_OPTIONS='--inspect=localhost:9230 --max-old-space-size=512' dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node dist/server.js",
+        "dev": "npm run intl:compile && run-s gql:types generate-block-types && tsc --project tsconfig.server.json && dotenv -e .env.secrets -e .env.local -e .env -e .env.site-configs -- node --inspect=localhost:9230 --max-old-space-size=512 dist/server.js",
         "generate-block-types": "comet generate-block-types",
         "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"npm run generate-block-types\"",
         "gql:types": "graphql-codegen",


### PR DESCRIPTION
Demo PR: https://github.com/vivid-planet/comet/pull/4265

## Old

NODE_OPTIONS where passed to dotenv (which is a node script itself), when attaching the debugger to 9230 you connected to the dotenv script, not the site script. The --max-old-space-size also had no effect.

## Now

As we start node ourself (without wrapper) we simply give the options directly to node.