### PR TITLE
gnore cometGen.tsx files in Knip

### DIFF
--- a/admin/knip.json
+++ b/admin/knip.json
@@ -3,7 +3,7 @@
     "workspaces": {
         ".": {
             "entry": ["./src/loader.ts"],
-            "ignore": ["./codegen.ts", "./schema.gql", "./src/**/generated/**/*.{ts,tsx}", "./src/**/*.cometGen.ts"],
+            "ignore": ["./codegen.ts", "./schema.gql", "./src/**/generated/**/*.{ts,tsx}", "./src/**/*.cometGen.{ts,tsx}"],
             "ignoreDependencies": ["@swc/plugin-emotion"],
             "project": ["./src/**/*.{ts,tsx}"]
         },


### PR DESCRIPTION
## Description

This Pull Request updates the Knip configuration to ignore `cometGen.tsx` files.

### False / Positive Error Message of unused file

<img width="422" height="59" alt="Screenshot 2025-08-22 at 10 11 28" src="https://github.com/user-attachments/assets/4f86ef0e-e7c9-4b54-82c9-4a3e0a020618" />


### Background:
- Normally, generated `.cometGen` files are created as `cometGen.ts`.
- when a React component is used inside a `renderCell`, the file must be renamed to `cometGen.tsx` to support JSX.

<img width="909" height="981" alt="Screenshot 2025-08-22 at 10 08 52" src="https://github.com/user-attachments/assets/a2b66d8a-359f-4c02-96bb-8798631a5e80" />



- Knip was incorrectly reporting these .tsx files as unused.
