### PR TITLE
Delay Renovate updates by 3 days using minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended", ":semanticCommitsDisabled"],
+    "minimumReleaseAge": "3 days",
+    "internalChecksFilter": "strict",
     "packageRules": [
         {
             "groupName": "comet",


### PR DESCRIPTION
## Description

This Pull Request updates the Renovate configuration to delay dependency updates until they are at least 3 days old.

- Renovate will not create dependency updates for new updates until the release has aged 3 days.
- Updates will appear as “Pending” in the Dependency Dashboard until the threshold is reached.
- This helps avoid adopting very fresh releases that may contain regressions and potential security risks.

see:
- https://docs.renovatebot.com/configuration-options/#minimumreleaseage
- https://docs.renovatebot.com/configuration-options/#internalchecksfilter

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2256
