### PR TITLE
A11y: Style links in RichTextBlock

### DIFF
--- a/site/src/common/blocks/RichTextBlock.tsx
+++ b/site/src/common/blocks/RichTextBlock.tsx
@@ -144,7 +144,6 @@ const InlineLink = styled(LinkBlock)`
 
     &:hover {
         color: ${({ theme }) => theme.palette.primary.dark};
-        text-decoration: underline;
         text-decoration-thickness: 2px;
     }
 `;


### PR DESCRIPTION
## Description

For better visibility, the underline of a Link should be thicker (2px), when hovering on it (in RichTextBlock)


## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

![Starter_InlineLink](https://github.com/user-attachments/assets/a9b4c8e8-8609-4a9b-bf76-b0f0cb7a12f7)

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2245
- PR in demo: https://github.com/vivid-planet/comet/pull/4373
