### PR TITLE
render eyebrow as p instead of headline

### DIFF
--- a/site/src/common/blocks/HeadingBlock.tsx
+++ b/site/src/common/blocks/HeadingBlock.tsx
@@ -41,7 +41,7 @@ export const HeadingBlock = withPreview(
         return (
             <>
                 {hasRichTextBlockContent(eyebrow) && (
-                    <Typography variant="h400" as="h5" bottomSpacing>
+                    <Typography variant="h400" as="p" bottomSpacing>
                         <RichTextBlock data={eyebrow} renderers={eyebrowRenderers} />
                     </Typography>
                 )}


### PR DESCRIPTION
## Description

At the moment the `eyebrow` in the `HeadingBlock` is rendered as a `h5`. This breaks the headline order. Therefor, the eyebrow should be rendered as a <strong> tag instead.

## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| Link   | Link  |

## Open TODOs/questions

-   [ ] 

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2242
- PR in Demo: https://github.com/vivid-planet/comet/pull/4371