### PR TITLE
A11y: Add title to Comet Logo

### DIFF
--- a/site/src/layout/header/Header.tsx
+++ b/site/src/layout/header/Header.tsx
@@ -44,7 +44,7 @@ export const Header = ({ header }: Props) => {
             <PageLayout grid>
                 <PageLayoutContent>
                     <Root>
-                        <Link href="/">
+                        <Link href="/" title={intl.formatMessage({ id: "header.logo.title", defaultMessage: "Comet DXP Logo" })}>
                             <SvgUse href="/assets/comet-logo.svg#root" />
                         </Link>
 


### PR DESCRIPTION
## Description

The logo in the header is not accessible. 
Make it accessible by providing a title and set aria-hidden to undefined if a title is provided.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="1419" height="232" alt="Screenshot 2025-08-28 at 11 09 21" src="https://github.com/user-attachments/assets/4afb12fb-447e-4938-a09a-e8ed2c053290" /> | <img width="1386" height="161" alt="Screenshot 2025-09-22 at 16 21 58" src="https://github.com/user-attachments/assets/e03d2f85-2779-4407-a8d4-8177676dae7d" />|

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2250
- PR in demo: https://github.com/vivid-planet/comet/pull/4431
