### PR TITLE
A11y: Fix order of elements in Footer

### DIFF
--- a/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -5,6 +5,7 @@ import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import { RichTextBlock } from "@src/common/blocks/RichTextBlock";
 import { Typography } from "@src/common/components/Typography";
 import { PageLayout } from "@src/layout/PageLayout";
+import { createImageSizes } from "@src/util/createImageSizes";
 import styled from "styled-components";
 
 export const FooterContentBlock = withPreview(
@@ -15,7 +16,12 @@ export const FooterContentBlock = withPreview(
                     <PageLayoutContent>
                         <TopContainer>
                             <ImageWrapper>
-                                <DamImageBlock data={image} aspectRatio="1/1" style={{ objectFit: "contain" }} />
+                                <DamImageBlock
+                                    data={image}
+                                    aspectRatio="1x1"
+                                    style={{ objectFit: "contain" }}
+                                    sizes={createImageSizes({ default: "20vw" })}
+                                />
                             </ImageWrapper>
                             <RichTextWrapper>
                                 <RichTextBlock data={text} disableLastBottomSpacing />


### PR DESCRIPTION
## Description

Setting row-reverse on a container, alters the order of elements visually but not in the DOM, which causes assistive technologies to use the wrong other. Use reading-flow: flex-visual; to resolve the issue.

+ improve usage of image

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Order on desktop:

<img width="1373" height="944" alt="Screenshot 2025-09-01 at 15 54 53" src="https://github.com/user-attachments/assets/4b32a223-ed79-452d-9d2b-efd99aebf356" />

Order on mobile:
<img width="842" height="939" alt="Screenshot 2025-09-01 at 15 55 14" src="https://github.com/user-attachments/assets/e8391c3c-8c2a-4933-acd0-87b03504c3a7" />


## Open TODOs/questions


## Further information

Task: https://vivid-planet.atlassian.net/browse/COM-2248
PR in demo: https://github.com/vivid-planet/comet/pull/4384