### PR TITLE
A11y: Improve AccordionItemBlock by adding titleHtmlTag to title

### DIFF
--- a/admin/src/common/blocks/AccordionItemBlock.tsx
+++ b/admin/src/common/blocks/AccordionItemBlock.tsx
@@ -5,6 +5,7 @@ import {
     createBlocksBlock,
     createCompositeBlock,
     createCompositeBlockField,
+    createCompositeBlockSelectField,
     createCompositeBlockTextField,
 } from "@comet/cms-admin";
 import { type AccordionItemBlockData } from "@src/blocks.generated";
@@ -35,6 +36,17 @@ export const AccordionItemBlock = createCompositeBlock(
                     fullWidth: true,
                 }),
                 hiddenInSubroute: true,
+            },
+            titleHtmlTag: {
+                block: createCompositeBlockSelectField<AccordionItemBlockData["titleHtmlTag"]>({
+                    label: <FormattedMessage id="accordionItem.titleHtmlTag" defaultMessage="Title HTML tag" />,
+                    defaultValue: "h3",
+                    options: ([1, 2, 3, 4, 5, 6] as const).map((level) => ({
+                        value: `h${level}`,
+                        label: <FormattedMessage id="accordionItem.headline" defaultMessage="Headline {level}" values={{ level }} />,
+                    })),
+                    required: true,
+                }),
             },
             content: {
                 block: AccordionContentBlock,

--- a/api/block-meta.json
+++ b/api/block-meta.json
@@ -151,6 +151,19 @@
                 "name": "openByDefault",
                 "kind": "Boolean",
                 "nullable": false
+            },
+            {
+                "name": "titleHtmlTag",
+                "kind": "Enum",
+                "enum": [
+                    "h1",
+                    "h2",
+                    "h3",
+                    "h4",
+                    "h5",
+                    "h6"
+                ],
+                "nullable": false
             }
         ],
         "inputFields": [
@@ -168,6 +181,19 @@
             {
                 "name": "openByDefault",
                 "kind": "Boolean",
+                "nullable": false
+            },
+            {
+                "name": "titleHtmlTag",
+                "kind": "Enum",
+                "enum": [
+                    "h1",
+                    "h2",
+                    "h3",
+                    "h4",
+                    "h5",
+                    "h6"
+                ],
                 "nullable": false
             }
         ]

--- a/api/src/common/blocks/accordion-item.block.ts
+++ b/api/src/common/blocks/accordion-item.block.ts
@@ -15,7 +15,16 @@ import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { SpaceBlock } from "@src/common/blocks/space.block";
 import { StandaloneCallToActionListBlock } from "@src/common/blocks/standalone-call-to-action-list.block";
 import { StandaloneHeadingBlock } from "@src/common/blocks/standalone-heading.block";
-import { IsBoolean, IsString } from "class-validator";
+import { IsBoolean, IsEnum, IsString } from "class-validator";
+
+export enum AccordionItemTitleHtmlTag {
+    h1 = "h1",
+    h2 = "h2",
+    h3 = "h3",
+    h4 = "h4",
+    h5 = "h5",
+    h6 = "h6",
+}
 
 export const AccordionContentBlock = createBlocksBlock(
     {
@@ -38,6 +47,9 @@ class AccordionItemBlockData extends BlockData {
 
     @BlockField()
     openByDefault: boolean;
+
+    @BlockField({ type: "enum", enum: AccordionItemTitleHtmlTag })
+    titleHtmlTag: AccordionItemTitleHtmlTag;
 }
 
 class AccordionItemBlockInput extends BlockInput {
@@ -52,6 +64,10 @@ class AccordionItemBlockInput extends BlockInput {
     @IsBoolean()
     @BlockField()
     openByDefault: boolean;
+
+    @IsEnum(AccordionItemTitleHtmlTag)
+    @BlockField({ type: "enum", enum: AccordionItemTitleHtmlTag })
+    titleHtmlTag: AccordionItemTitleHtmlTag;
 
     transformToBlockData(): AccordionItemBlockData {
         return blockInputToData(AccordionItemBlockData, this);

--- a/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
@@ -2,7 +2,7 @@ import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { AccordionBlock } from "@src/common/blocks/accordion.block";
-import { AccordionContentBlock, AccordionItemBlock } from "@src/common/blocks/accordion-item.block";
+import { AccordionContentBlock, AccordionItemBlock, AccordionItemTitleHtmlTag } from "@src/common/blocks/accordion-item.block";
 
 import { BlockFixture } from "../block-fixture";
 import { StandaloneCallToActionListBlockFixtureService } from "../navigation/standalone-call-to-action-list-block-fixture.service";
@@ -51,6 +51,7 @@ export class AccordionBlockFixtureService {
             title: faker.lorem.words({ min: 3, max: 9 }),
             content: await this.generateAccordionContentBlock(),
             openByDefault: faker.datatype.boolean(),
+            titleHtmlTag: faker.helpers.arrayElement(Object.values(AccordionItemTitleHtmlTag)),
         };
     }
 

--- a/site/src/common/blocks/AccordionItemBlock.tsx
+++ b/site/src/common/blocks/AccordionItemBlock.tsx
@@ -30,14 +30,16 @@ type AccordionItemBlockProps = PropsWithData<AccordionItemBlockData> & {
 };
 
 export const AccordionItemBlock = withPreview(
-    ({ data: { title, content }, isExpanded, onChange }: AccordionItemBlockProps) => {
+    ({ data: { title, content, titleHtmlTag }, isExpanded, onChange }: AccordionItemBlockProps) => {
         const headlineId = useId();
         const contentId = useId();
 
         return (
             <>
                 <TitleWrapper id={headlineId} onClick={onChange} aria-expanded={isExpanded} aria-controls={contentId}>
-                    <Typography variant="h350">{title}</Typography>
+                    <Typography variant="h350" as={titleHtmlTag}>
+                        {title}
+                    </Typography>
                     <IconWrapper>
                         <AnimatedChevron href="/assets/icons/chevron-down.svg#root" $isExpanded={isExpanded} />
                     </IconWrapper>


### PR DESCRIPTION
## Description

The title in an AccordionItem is hardcoded as a h6. This is problematic as the headline order might be broken.

Therefor an additional field titleHtmlTag is added to the block, so that it is possible to set the html tag manually.


## Acceptance criteria

-   [ ] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [ ] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Admin: 
<img width="1419" height="658" alt="Screenshot 2025-09-01 at 16 10 48" src="https://github.com/user-attachments/assets/1751c1b1-ed25-4394-9959-1a7c86ebad67" />


Site: 
<img width="1080" height="177" alt="Screenshot 2025-09-01 at 16 11 11" src="https://github.com/user-attachments/assets/035be51a-9757-4cca-bc82-4c60d2e7725b" />

## Open TODOs/questions

-   [ ] 

## Further information

Task: https://vivid-planet.atlassian.net/browse/COM-2244
PR in demo: https://github.com/vivid-planet/comet/pull/4379