### PR TITLE
A11y: Improve TeaserItemBlock by adding htmlTag to title

### DIFF
--- a/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/admin/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -1,4 +1,11 @@
-import { BlockCategory, createCompositeBlock, createCompositeBlockTextField, createRichTextBlock } from "@comet/cms-admin";
+import {
+    BlockCategory,
+    createCompositeBlock,
+    createCompositeBlockSelectField,
+    createCompositeBlockTextField,
+    createRichTextBlock,
+} from "@comet/cms-admin";
+import { type TeaserItemBlockData } from "@src/blocks.generated";
 import { LinkBlock } from "@src/common/blocks/LinkBlock";
 import { MediaBlock } from "@src/common/blocks/MediaBlock";
 import { TextLinkBlock } from "@src/common/blocks/TextLinkBlock";
@@ -26,6 +33,17 @@ export const TeaserItemBlock = createCompositeBlock(
                 block: createCompositeBlockTextField({
                     label: <FormattedMessage id="teaserItemBlock.title" defaultMessage="Title" />,
                     fullWidth: true,
+                }),
+            },
+            titleHtmlTag: {
+                block: createCompositeBlockSelectField<TeaserItemBlockData["titleHtmlTag"]>({
+                    label: <FormattedMessage id="teaserItemBlock.titleHtmlTag" defaultMessage="Title HTML tag" />,
+                    defaultValue: "h3",
+                    options: ([1, 2, 3, 4, 5, 6] as const).map((level) => ({
+                        value: `h${level}`,
+                        label: <FormattedMessage id="teaserItemBlock.headline" defaultMessage="Headline {level}" values={{ level }} />,
+                    })),
+                    required: true,
                 }),
             },
             description: {

--- a/api/block-meta.json
+++ b/api/block-meta.json
@@ -2719,6 +2719,19 @@
                 "kind": "Block",
                 "block": "TextLink",
                 "nullable": false
+            },
+            {
+                "name": "titleHtmlTag",
+                "kind": "Enum",
+                "enum": [
+                    "h1",
+                    "h2",
+                    "h3",
+                    "h4",
+                    "h5",
+                    "h6"
+                ],
+                "nullable": false
             }
         ],
         "inputFields": [
@@ -2743,6 +2756,19 @@
                 "name": "link",
                 "kind": "Block",
                 "block": "TextLink",
+                "nullable": false
+            },
+            {
+                "name": "titleHtmlTag",
+                "kind": "Enum",
+                "enum": [
+                    "h1",
+                    "h2",
+                    "h3",
+                    "h4",
+                    "h5",
+                    "h6"
+                ],
                 "nullable": false
             }
         ]

--- a/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
@@ -2,7 +2,7 @@ import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
 import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { TeaserBlock } from "@src/documents/pages/blocks/teaser.block";
-import { TeaserItemBlock } from "@src/documents/pages/blocks/teaser-item.block";
+import { TeaserItemBlock, TeaserItemTitleHtmlTag } from "@src/documents/pages/blocks/teaser-item.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";
 import { TextLinkBlockFixtureService } from "../navigation/text-link-block-fixture.service";
@@ -22,6 +22,7 @@ export class TeaserBlockFixtureService {
             title: faker.lorem.words({ min: 3, max: 9 }),
             description: await this.richTextBlockFixtureService.generateBlockInput(),
             link: await this.textLinkBlockFixtureService.generateBlockInput(),
+            titleHtmlTag: faker.helpers.arrayElement(Object.values(TeaserItemTitleHtmlTag)),
         };
     }
 

--- a/api/src/documents/pages/blocks/teaser-item.block.ts
+++ b/api/src/documents/pages/blocks/teaser-item.block.ts
@@ -12,7 +12,16 @@ import {
 import { MediaBlock } from "@src/common/blocks/media.block";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
 import { TextLinkBlock } from "@src/common/blocks/text-link.block";
-import { IsString } from "class-validator";
+import { IsEnum, IsString } from "class-validator";
+
+export enum TeaserItemTitleHtmlTag {
+    h1 = "h1",
+    h2 = "h2",
+    h3 = "h3",
+    h4 = "h4",
+    h5 = "h5",
+    h6 = "h6",
+}
 
 class TeaserItemBlockData extends BlockData {
     @ChildBlock(MediaBlock)
@@ -26,6 +35,9 @@ class TeaserItemBlockData extends BlockData {
 
     @ChildBlock(TextLinkBlock)
     link: BlockDataInterface;
+
+    @BlockField({ type: "enum", enum: TeaserItemTitleHtmlTag })
+    titleHtmlTag: TeaserItemTitleHtmlTag;
 }
 
 class TeaserItemBlockInput extends BlockInput {
@@ -41,6 +53,10 @@ class TeaserItemBlockInput extends BlockInput {
 
     @ChildBlockInput(TextLinkBlock)
     link: ExtractBlockInput<typeof TextLinkBlock>;
+
+    @IsEnum(TeaserItemTitleHtmlTag)
+    @BlockField({ type: "enum", enum: TeaserItemTitleHtmlTag })
+    titleHtmlTag: TeaserItemTitleHtmlTag;
 
     transformToBlockData(): TeaserItemBlockData {
         return blockInputToData(TeaserItemBlockData, this);

--- a/site/src/documents/pages/blocks/TeaserItemBlock.tsx
+++ b/site/src/documents/pages/blocks/TeaserItemBlock.tsx
@@ -14,7 +14,7 @@ const descriptionRenderers: Renderers = {
 };
 
 export const TeaserItemBlock = withPreview(
-    ({ data: { media, title, description, link } }: PropsWithData<TeaserItemBlockData>) => (
+    ({ data: { media, title, description, link, titleHtmlTag } }: PropsWithData<TeaserItemBlockData>) => (
         <RootLinkBlock data={link.link}>
             <MediaMobile>
                 <MediaBlock data={media} aspectRatio="1x1" sizes={createImageSizes({ default: "20vw" })} />
@@ -23,7 +23,9 @@ export const TeaserItemBlock = withPreview(
                 <MediaBlock data={media} aspectRatio="16x9" sizes={createImageSizes({ default: "20vw" })} />
             </MediaDesktop>
             <ContentContainer>
-                <TitleTypography variant="h350">{title}</TitleTypography>
+                <TitleTypography variant="h350" as={titleHtmlTag}>
+                    {title}
+                </TitleTypography>
                 <Typography variant="p200">
                     <RichTextBlock data={description} renderers={descriptionRenderers} />
                 </Typography>


### PR DESCRIPTION
## Description

The title in an TeaserItemBlock is hardcoded as a h6. This is problematic as the headline order might be broken.

Therefor an additional field htmlTag is added to the block, so that it is possible to set the html tag manually.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Admin: 
<img width="1604" height="479" alt="Screenshot 2025-09-02 at 09 59 19" src="https://github.com/user-attachments/assets/deb93859-e3e6-4bbb-8dad-6f57a2c245e0" />



Site (with two different htmlTags):
<img width="1486" height="339" alt="Screenshot 2025-09-02 at 10 01 09" src="https://github.com/user-attachments/assets/1de15b0e-7d31-405d-abcb-f989b6c3b741" />

## Further information

Task: https://vivid-planet.atlassian.net/browse/COM-2243
PR in demo: https://github.com/vivid-planet/comet/pull/4380