### PR TITLE
Dev: Change default server host to localhost and allow change via env var for admin-server #3860

### DIFF
--- a/admin/server/index.js
+++ b/admin/server/index.js
@@ -7,6 +7,7 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 
 const app = express();
 const port = process.env.APP_PORT ?? 3000;
+const host = process.env.SERVER_HOST ?? "localhost";
 
 let indexFile = fs.readFileSync("./build/index.html", "utf8");
 
@@ -90,6 +91,6 @@ app.get("*", (req, res) => {
     res.send(indexFile);
 });
 
-app.listen(port, () => {
-    console.log(`Admin app listening at http://localhost:${port}`);
+app.listen(port, host, () => {
+    console.log(`Admin app listening at http://${host}:${port}`);
 });


### PR DESCRIPTION
brings following Demo change https://github.com/vivid-planet/comet/pull/3860 to comet-starter

---

This pull Request adds the capability to configure the admin's host via environment variable (`SERVER_HOST `)
