### PR TITLE
Generate GraphQL types in admin-generator script

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "admin-generator": "rimraf --glob 'src/**/generated' && comet-admin-generator generate",
+        "admin-generator": "rimraf --glob 'src/**/generated' && comet-admin-generator generate && npm run gql:types",
         "build": "run-s admin-generator intl:compile && run-p gql:types generate-block-types && NODE_ENV=production vite build",
         "generate-block-types": "comet generate-block-types --inputs",
         "generate-block-types:watch": "chokidar -s \"block-meta.json\" -c \"npm run generate-block-types\"",


### PR DESCRIPTION
Add missing step from Demo change ([PR #3567](https://github.com/vivid-planet/comet/pull/3567)): 
- generate types after running the admin-generator in comet-starter.