### PR TITLE
Use createFetchWithDefaultNextRevalidate that applies next.revalidate only if cache is not set

### DIFF
--- a/site/src/util/graphQLClient.ts
+++ b/site/src/util/graphQLClient.ts
@@ -1,5 +1,6 @@
 import {
     convertPreviewDataToHeaders,
+    createFetchWithDefaultNextRevalidate,
     createFetchWithDefaults,
     createGraphQLFetch as createGraphQLFetchLibrary,
     type SitePreviewData,
@@ -26,10 +27,7 @@ export function createGraphQLFetch() {
     return createGraphQLFetchLibrary(
         // set a default revalidate time of 7.5 minutes to get an effective cache duration of 15 minutes if a CDN cache is enabled
         // see cache-handler.ts for maximum cache duration (24 hours)
-        createFetchWithDefaults(fetch, {
-            next: {
-                revalidate: 7.5 * 60,
-            },
+        createFetchWithDefaults(createFetchWithDefaultNextRevalidate(fetch, 7.5 * 60), {
             headers: {
                 authorization: `Basic ${Buffer.from(`system-user:${process.env.API_BASIC_AUTH_SYSTEM_USER_PASSWORD}`).toString("base64")}`,
                 ...convertPreviewDataToHeaders(previewData),


### PR DESCRIPTION
This works around the error 'specified "cache: no-store" and "revalidate: 450", only one should be specified.'

See https://github.com/vivid-planet/comet/pull/4194 for change in demo