### PR TITLE
A11y: Improve font-sizes of <sub> and <sup> elements

### DIFF
--- a/site/src/layout/GlobalStyle.ts
+++ b/site/src/layout/GlobalStyle.ts
@@ -46,7 +46,7 @@ export const GlobalStyle = createGlobalStyle`
     /* Prevent sub and sup elements from affecting the line height in all browsers */
     sub,
     sup {
-        font-size: 75%;
+        font-size: max(12px, 75%);
         line-height: 0;
         position: relative;
         vertical-align: baseline;


### PR DESCRIPTION
## Description

Text should have at least a size of 12px to be accessible.

Problem: the font-size of `<sub>` and `<sup>` elements is given with 75% of its parent, which can lead to values smaller than 12px, e.g. in the RichTextBlock using the "Paragraph small" variant.

To fix this, a minimum value of 12px is set to those elements globally using the max() function.

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

| Before | After |
| ------ | ----- |
| <img width="330" height="213" alt="Screenshot 2025-09-11 at 09 11 29" src="https://github.com/user-attachments/assets/7d376108-8945-4ccc-8ae5-047804ef6102" />   |  <img width="321" height="218" alt="Screenshot 2025-09-11 at 09 10 13" src="https://github.com/user-attachments/assets/829b5ac7-5c61-4bbe-a858-d34da620f92d" />  |

## Open TODOs/questions

-   [ ] 

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2255
- PR in Demo: https://github.com/vivid-planet/comet/pull/4479