### PR TITLE
Localization - add language parameter to getMessages

### DIFF
--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -81,7 +81,7 @@ export function App() {
             redirects={{ scopeParts: ["domain"] }}
         >
             <ApolloProvider client={apolloClient}>
-                <IntlProvider locale="en" messages={getMessages()}>
+                <IntlProvider locale="en" messages={getMessages("en")}>
                     <LocalizationProvider adapterLocale={enUS} dateAdapter={AdapterDateFns}>
                         <MuiThemeProvider theme={theme}>
                             <DndProvider options={HTML5toTouch}>

--- a/admin/src/lang.ts
+++ b/admin/src/lang.ts
@@ -15,7 +15,14 @@ const projectMessages = {
     de: project_messages_de,
 };
 
-export const getMessages = (): ResolvedIntlConfig["messages"] => {
+export const getMessages = (language: "de" | "en"): ResolvedIntlConfig["messages"] => {
+    if (language === "de") {
+        return {
+            ...cometMessages["de"],
+            ...projectMessages["de"],
+        };
+    }
+
     return {
         ...cometMessages["en"],
         ...projectMessages["en"],


### PR DESCRIPTION
## Description

This PR enhances the `getMessages` function in Comet Starter to support localization. The function now accepts a language parameter and returns messages in the selected language.

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2501
