### PR TITLE
Fix size of ToggleButton in Header

### DIFF
--- a/site/src/layout/header/Header.tsx
+++ b/site/src/layout/header/Header.tsx
@@ -176,13 +176,13 @@ const ToggleSubLevelNavigationButton = styled.button`
     background-color: transparent;
     color: inherit;
     padding: 0;
-    width: 20px;
-    height: 20px;
+    width: 24px;
+    height: 24px;
 `;
 
 const AnimatedChevron = styled(SvgUse)<{ $isExpanded: boolean }>`
-    width: 100%;
-    height: 100%;
+    width: 20px;
+    height: 20px;
     color: ${({ theme, $isExpanded }) => ($isExpanded ? theme.palette.primary.main : theme.palette.text.primary)};
     transform: rotate(${({ $isExpanded }) => ($isExpanded ? "-180deg" : "0deg")});
     transition: transform 0.4s ease;


### PR DESCRIPTION
## Description

Fix size of ToggleSubLevelNavigationButton (must be at least 24 px)

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts
Button:
<img width="341" height="250" alt="Screenshot 2025-09-22 at 15 25 03" src="https://github.com/user-attachments/assets/60e84a97-1025-4fa8-a51e-bec90bc3fbd8" />

SVG: 
<img width="348" height="186" alt="Screenshot 2025-09-22 at 15 25 13" src="https://github.com/user-attachments/assets/7a54ae47-c761-4ca2-b35a-6ed6986bb036" />


## Open TODOs/questions

-   [ ] 

## Further information

-  Task: https://vivid-planet.atlassian.net/browse/COM-2253
- PR in demo: https://github.com/vivid-planet/comet/pull/4530
