### PR TITLE
A11y: add skip links to site

### DIFF
--- a/site/src/documents/pages/Page.tsx
+++ b/site/src/documents/pages/Page.tsx
@@ -135,7 +135,8 @@ export async function Page({ pageTreeNodeId, scope }: { pageTreeNodeId: string; 
             {document.seo.structuredData && document.seo.structuredData.length > 0 && (
                 <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: document.seo.structuredData }} />
             )}
-            <main>
+            {/* ID is used for skip link */}
+            <main id="mainContent">
                 <StageBlock data={document.stage} />
                 <PageContentBlock data={document.content} />
             </main>

--- a/site/src/layout/footer/blocks/FooterContentBlock.tsx
+++ b/site/src/layout/footer/blocks/FooterContentBlock.tsx
@@ -11,7 +11,8 @@ import styled from "styled-components";
 export const FooterContentBlock = withPreview(
     ({ data: { text, image, linkList, copyrightNotice } }: PropsWithData<FooterContentBlockData>) => {
         return (
-            <Root>
+            // ID is used for skip link
+            <Root id="footer">
                 <PageLayout grid>
                     <PageLayoutContent>
                         <TopContainer>

--- a/site/src/layout/header/Header.tsx
+++ b/site/src/layout/header/Header.tsx
@@ -1,11 +1,12 @@
 "use client";
+import { Button } from "@src/common/components/Button";
 import { SvgUse } from "@src/common/helpers/SvgUse";
 import { MobileMenu } from "@src/layout/header/MobileMenu";
 import { PageLink } from "@src/layout/header/PageLink";
 import { PageLayout } from "@src/layout/PageLayout";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { useIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import styled from "styled-components";
 
 import { type GQLHeaderFragment } from "./Header.fragment.generated";
@@ -41,6 +42,16 @@ export const Header = ({ header }: Props) => {
 
     return (
         <header>
+            <SkipLink href="#mainContent">
+                <Button as="span">
+                    <FormattedMessage defaultMessage="Skip to main content" id="skipLink.skipToMainContent" />
+                </Button>
+            </SkipLink>
+            <SkipLink href="#footer">
+                <Button as="span">
+                    <FormattedMessage defaultMessage="Skip to footer" id="skipLink.skipToFooter" />
+                </Button>
+            </SkipLink>
             <PageLayout grid>
                 <PageLayoutContent>
                     <Root>
@@ -105,6 +116,28 @@ export const Header = ({ header }: Props) => {
         </header>
     );
 };
+
+const SkipLink = styled.a`
+    position: fixed;
+    top: 120px;
+    left: 20px;
+    z-index: 100;
+    opacity: 0;
+
+    /* Hide the skip link visually but keep it accessible for screen readers */
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    white-space: nowrap;
+    clip-path: inset(50%);
+
+    &:focus {
+        opacity: 1;
+        height: auto;
+        width: auto;
+        clip-path: none;
+    }
+`;
 
 const PageLayoutContent = styled.div`
     grid-column: 2 / -2;


### PR DESCRIPTION
## Description

Add skip links for main content and footer to the side. Skip links should be the first element in the tab order.

_Note: Focus styling from the design (magenta outline) will be added in an upcoming PR globally for all elements_

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Tab order:

https://github.com/user-attachments/assets/2f1ae0f4-0251-4998-8eb5-37e177c5d09b


Skip to main content:

https://github.com/user-attachments/assets/56b43e67-3c3e-4c10-ba2e-d08eb4bcebc3


Skip to footer:

https://github.com/user-attachments/assets/40b9add8-be3b-47cb-889e-ea3d600d934c



## Open TODOs/questions

-   [ ] 

## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2171
- PR in demo: https://github.com/vivid-planet/comet/pull/4481
