### PR TITLE
Update variants of ColumnsBlock

### DIFF
--- a/admin/src/documents/pages/blocks/ColumnsBlock.tsx
+++ b/admin/src/documents/pages/blocks/ColumnsBlock.tsx
@@ -41,7 +41,7 @@ const oneColumnLayouts = [
         ),
     },
     {
-        name: "9-6-9",
+        name: "6-12-6",
         columns: 1,
         label: <FormattedMessage id="columnsBlock.center.small" defaultMessage="Center small" />,
         preview: (

--- a/admin/src/documents/pages/blocks/ColumnsBlock.tsx
+++ b/admin/src/documents/pages/blocks/ColumnsBlock.tsx
@@ -46,9 +46,9 @@ const oneColumnLayouts = [
         label: <FormattedMessage id="columnsBlock.center.small" defaultMessage="Center small" />,
         preview: (
             <ColumnsLayoutPreview>
-                <ColumnsLayoutPreviewSpacing width={9} />
-                <ColumnsLayoutPreviewContent width={6} />
-                <ColumnsLayoutPreviewSpacing width={9} />
+                <ColumnsLayoutPreviewSpacing width={6} />
+                <ColumnsLayoutPreviewContent width={12} />
+                <ColumnsLayoutPreviewSpacing width={6} />
             </ColumnsLayoutPreview>
         ),
     },

--- a/api/src/documents/pages/blocks/columns.block.ts
+++ b/api/src/documents/pages/blocks/columns.block.ts
@@ -20,14 +20,12 @@ export const ColumnsContentBlock = createBlocksBlock(
             mediaGallery: MediaGalleryBlock,
         },
     },
-    {
-        name: "ColumnsContent",
-    },
+    { name: "ColumnsContent" },
 );
 
 export const ColumnsBlock = ColumnsBlockFactory.create(
     {
-        layouts: [{ name: "2-20-2" }, { name: "4-16-4" }, { name: "9-6-9" }, { name: "9-9" }, { name: "12-6" }, { name: "6-12" }],
+        layouts: [{ name: "2-20-2" }, { name: "4-16-4" }, { name: "6-12-6" }, { name: "9-9" }, { name: "12-6" }, { name: "6-12" }],
         contentBlock: ColumnsContentBlock,
     },
     "Columns",

--- a/site/src/documents/pages/blocks/ColumnsBlock.tsx
+++ b/site/src/documents/pages/blocks/ColumnsBlock.tsx
@@ -46,21 +46,11 @@ const Column = styled.div<{ $layout: string }>`
     grid-column: 3 / -3;
 
     ${({ $layout, theme }) =>
-        $layout === "9-6-9" &&
+        $layout === "6-12-6" &&
         css`
-            grid-column: 5 / -5;
-
+            grid-column: 4 / -4;
             ${theme.breakpoints.sm.mediaQuery} {
                 grid-column: 7 / -7;
-            }
-            ${theme.breakpoints.md.mediaQuery} {
-                grid-column: 8 / -8;
-            }
-            ${theme.breakpoints.lg.mediaQuery} {
-                grid-column: 9 / -9;
-            }
-            ${theme.breakpoints.xl.mediaQuery} {
-                grid-column: 10 / -10;
             }
         `};
 


### PR DESCRIPTION
## Description

The variants of the ColumnsBlock were revised by UX.

The 9-6-9(small) variant is changed to a 6-12-6 grid layout (except mobile it is 3-18-3)

## Acceptance criteria

-   [x] I have verified if my change requires [an example](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#example)
-   [x] I have verified if my change requires [screenshots/screencasts](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md#screenshotsscreencasts)

## Screenshots/screencasts

Admin:
<img width="1413" height="715" alt="Bildschirmfoto 2025-09-25 um 10 08 42" src="https://github.com/user-attachments/assets/8a711aa9-5ba6-40b0-a919-6f2a533d9b6f" />


Desktop:
<img width="1155" height="465" alt="Bildschirmfoto 2025-09-25 um 10 09 14" src="https://github.com/user-attachments/assets/1ed3e145-58e0-41ab-8a8f-71a7f7f5d49c" />


Mobile:
<img width="443" height="527" alt="Bildschirmfoto 2025-09-25 um 10 09 35" src="https://github.com/user-attachments/assets/bd952505-9ea7-4082-91ca-5514f7d37b1f" />



## Open TODOs/questions

-   [ ] 

## Further information

- Task: https://vivid-planet.atlassian.net/browse/COM-2485
- PR in demo: https://github.com/vivid-planet/comet/pull/4551