### PR TITLE
Add default focus styling globally

### DIFF
--- a/site/src/styles/global.scss
+++ b/site/src/styles/global.scss
@@ -34,6 +34,7 @@
     --palette-success-light: #77d06a;
     --palette-success-dark: #488938;
     --palette-success-contrastText: #090909;
+    --palette-functional-highlight-main: #d817fa;
     --font-family: Roboto, sans-serif;
     --spacing-d400: 72px;
     --spacing-d300: 44px;
@@ -175,4 +176,10 @@ legend {
 #root,
 #__next {
     isolation: isolate;
+}
+
+:focus {
+    outline: 3px solid var(--palette-functional-highlight-main);
+    outline-offset: 0;
+    border: 2px solid var(--palette-primary-contrastText);
 }


### PR DESCRIPTION
## Description

Add default focus styles globally using the new color for highlights.

## Screenshots/screencasts
<img width="361" height="249" alt="Bildschirmfoto 2025-09-30 um 11 18 09" src="https://github.com/user-attachments/assets/d29d669b-45ce-435a-ad7d-2839abe3288b" />


## Further information

-   Task: https://vivid-planet.atlassian.net/browse/COM-2173
- PR in Demo: https://github.com/vivid-planet/comet/pull/4577
