### PR TITLE
Switch probes to dedicated /healthcheck/{live,ready} endpoints

### DIFF
--- a/.cspellignore
+++ b/.cspellignore
@@ -31,6 +31,7 @@ timestamptz
 formatjs
 cspellignore
 graphiql
+healthcheck
 bitnamilegacy
 usehooks
 valkey

--- a/.digitalocean/comet-starter-cms.tpl.yaml
+++ b/.digitalocean/comet-starter-cms.tpl.yaml
@@ -235,7 +235,7 @@ services:
         value: "true"
       - key: OAUTH2_PROXY_SKIP_AUTH_ROUTES
         scope: RUN_AND_BUILD_TIME
-        value: "^(/api)?/status/"
+        value: "^(/api)?/healthcheck/"
       - key: OAUTH2_PROXY_SKIP_JWT_BEARER_TOKENS
         scope: RUN_AND_BUILD_TIME
         value: "true"

--- a/.docker-compose/docker-compose.tpl.yml
+++ b/.docker-compose/docker-compose.tpl.yml
@@ -62,7 +62,7 @@ services:
       OAUTH2_PROXY_API_ROUTES: "/api"
       OAUTH2_PROXY_EMAIL_DOMAINS: "*"
       OAUTH2_PROXY_SKIP_AUTH_PREFLIGHT: "true"
-      OAUTH2_PROXY_SKIP_AUTH_ROUTES: "^(/api)?/status/"
+      OAUTH2_PROXY_SKIP_AUTH_ROUTES: "^(/api)?/healthcheck/"
       OAUTH2_PROXY_SKIP_JWT_BEARER_TOKENS: "true"
       OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
       OAUTH2_PROXY_WHITELIST_DOMAIN: "auth-sso.vivid-planet.cloud"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,7 +168,7 @@ After making code changes, always run `npm --prefix <package> run lint:fix` for 
 
 ### API Module Structure
 
-Feature-based organization: `auth/`, `documents/`, `dam/`, `menus/`, `footers/`, `redirects/`, `status/`
+Feature-based organization: `auth/`, `documents/`, `dam/`, `menus/`, `footers/`, `redirects/`, `healthcheck/`
 
 ### Admin Structure
 

--- a/admin/server/index.js
+++ b/admin/server/index.js
@@ -55,7 +55,7 @@ app.use(
     }),
 );
 
-app.get("/status/health", (req, res) => {
+app.get(["/healthcheck/live", "/healthcheck/ready"], (req, res) => {
     res.setHeader("cache-control", "no-store");
     res.send("OK!");
 });

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -22,6 +22,7 @@ import { LinksModule } from "@src/documents/links/links.module";
 import { Page } from "@src/documents/pages/entities/page.entity";
 import { PagesModule } from "@src/documents/pages/pages.module";
 import { FootersModule } from "@src/footers/footers.module";
+import { HealthcheckModule } from "@src/healthcheck/healthcheck.module";
 import { PageTreeNodeScope } from "@src/page-tree/dto/page-tree-node-scope";
 import { PageTreeNode } from "@src/page-tree/entities/page-tree-node.entity";
 import { RedirectScope } from "@src/redirects/dto/redirect-scope";
@@ -36,7 +37,6 @@ import { ConfigModule } from "./config/config.module";
 import { DamFile } from "./dam/entities/dam-file.entity";
 import { DamFolder } from "./dam/entities/dam-folder.entity";
 import { MenusModule } from "./menus/menus.module";
-import { StatusModule } from "./status/status.module";
 
 @Module({})
 export class AppModule {
@@ -130,7 +130,7 @@ export class AppModule {
                         maxSrcResolution: config.dam.maxSrcResolution,
                     },
                 }),
-                StatusModule,
+                HealthcheckModule,
                 MenusModule,
                 DependenciesModule,
                 FootersModule,
@@ -138,7 +138,7 @@ export class AppModule {
                 ...(!config.debug
                     ? [
                           AccessLogModule.forRoot({
-                              shouldLogRequest: ({ user, req }) => user !== SYSTEM_USER_NAME && !req.route.path.startsWith("/api/status/"),
+                              shouldLogRequest: ({ user, req }) => user !== SYSTEM_USER_NAME && !req.route.path.startsWith("/api/healthcheck/"),
                           }),
                       ]
                     : []),

--- a/api/src/healthcheck/healthcheck.controller.ts
+++ b/api/src/healthcheck/healthcheck.controller.ts
@@ -2,22 +2,22 @@ import { DisableCometGuards } from "@comet/cms-api";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Controller, Get, Header } from "@nestjs/common";
 
-@Controller("status")
+@Controller("healthcheck")
 @DisableCometGuards()
-export class StatusController {
+export class HealthcheckController {
     constructor(private readonly entityManager: EntityManager) {}
 
-    @Get("liveness")
+    @Get("live")
     @Header("cache-control", "no-store")
-    liveness(): string {
+    live(): string {
         // If this controller returns a non 2xx status code, the pod is restarted by kubernetes
         // see https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
         return "OK";
     }
 
-    @Get("readiness")
+    @Get("ready")
     @Header("cache-control", "no-store")
-    async readiness(): Promise<string> {
+    async ready(): Promise<string> {
         // If this controller returns a non 2xx status code, the pod does not receive traffic
         // If the database is not available, it does not make sense to restart the pod
         // However, the pod should not receive traffic anymore as it can't handle it without the database

--- a/api/src/healthcheck/healthcheck.module.ts
+++ b/api/src/healthcheck/healthcheck.module.ts
@@ -1,0 +1,6 @@
+import { Module } from "@nestjs/common";
+
+import { HealthcheckController } from "./healthcheck.controller";
+
+@Module({ controllers: [HealthcheckController] })
+export class HealthcheckModule {}

--- a/api/src/status/status.module.ts
+++ b/api/src/status/status.module.ts
@@ -1,6 +1,0 @@
-import { Module } from "@nestjs/common";
-
-import { StatusController } from "./status.controller";
-
-@Module({ controllers: [StatusController] })
-export class StatusModule {}

--- a/site/src/middleware.ts
+++ b/site/src/middleware.ts
@@ -3,14 +3,14 @@ import { chain } from "./middleware/chain";
 import { withContentSecurityPolicyHeadersMiddleware } from "./middleware/contentSecurityPolicyHeaders";
 import { withDamRewriteMiddleware } from "./middleware/damRewrite";
 import { withDomainRewriteMiddleware } from "./middleware/domainRewrite";
+import { withHealthcheckMiddleware } from "./middleware/healthcheck";
 import { withPreviewMiddleware } from "./middleware/preview";
 import { withRedirectToMainHostMiddleware } from "./middleware/redirectToMainHost";
 import { withRobotsMiddleware } from "./middleware/robots";
 import { withSkipRewriteMiddleware } from "./middleware/skipRewrite";
-import { withStatusMiddleware } from "./middleware/status";
 
 export default chain([
-    withStatusMiddleware,
+    withHealthcheckMiddleware,
     withAdminRedirectMiddleware,
     withSkipRewriteMiddleware,
     withDamRewriteMiddleware,

--- a/site/src/middleware/healthcheck.ts
+++ b/site/src/middleware/healthcheck.ts
@@ -2,9 +2,9 @@ import { type NextRequest, NextResponse } from "next/server";
 
 import { type CustomMiddleware } from "./chain";
 
-export function withStatusMiddleware(middleware: CustomMiddleware) {
+export function withHealthcheckMiddleware(middleware: CustomMiddleware) {
     return async (request: NextRequest) => {
-        if (request.nextUrl.pathname === "/api/status") {
+        if (["/healthcheck/live", "/healthcheck/ready"].includes(request.nextUrl.pathname)) {
             return NextResponse.json({ status: "OK" }, { headers: { "cache-control": "no-store" } });
         }
         return middleware(request);


### PR DESCRIPTION
## Summary

Aligns api, admin, and site with the new [comet-charts major versions](https://github.com/vivid-planet/comet-charts/pull/194) (`comet-api-v3`, `comet-admin-v2`, `comet-site-v2`), which switched their `livenessProbe`/`readinessProbe`/`startupProbe` paths to dedicated `/healthcheck/*` endpoints to reduce noise from health-check requests in monitoring tools (e.g. Sentry false positives that can't be filtered via inbound filters).

- `api`: `/api/status/{liveness,readiness}` → `/api/healthcheck/{live,ready}` (NestJS `StatusController`/`StatusModule` renamed to `HealthcheckController`/`HealthcheckModule`, access-log filter updated)
- `admin`: `/status/health` → `/healthcheck/{live,ready}` (single Express handler bound to both paths)
- `site`: `/api/status` → `/healthcheck/{live,ready}` (`withStatusMiddleware` → `withHealthcheckMiddleware`)
- `oauth2-proxy`: `OAUTH2_PROXY_SKIP_AUTH_ROUTES` regex `^(/api)?/status/` → `^(/api)?/healthcheck/` in both `.docker-compose/docker-compose.tpl.yml` and `.digitalocean/comet-starter-cms.tpl.yaml`
- `AGENTS.md`: feature-folder list updated (`status/` → `healthcheck/`)
- `.cspellignore`: added `healthcheck`

**Breaking change for charts:** the new chart majors expect the new endpoints — deploy this app change *before* upgrading the chart, otherwise probes will fail.

## Test plan

- [x] `npm run dev` and verify each service responds 200 at its new endpoint(s)
  - [x] `curl http://localhost:4000/api/healthcheck/live` (API)
  - [x] `curl http://localhost:4000/api/healthcheck/ready` (API, hits DB)
  - [x] `curl http://localhost:8000/healthcheck/live` (Admin)
  - [x] `curl http://localhost:8000/healthcheck/ready` (Admin)
  - [x] `curl http://localhost:3000/healthcheck/live` (Site)
  - [x] `curl http://localhost:3000/healthcheck/ready` (Site)
- [x] Verify oauth2-proxy still skips auth on the new paths (no redirect on `/api/healthcheck/*` and `/healthcheck/*` via the docker-compose stack)
- [x] `npm run lint` clean
- [x] `npm --prefix api run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)