### PR TITLE
Set min-release-age for packages to three days in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 strict-peer-deps=true
+min-release-age=3


### PR DESCRIPTION
Since v11.10.0 npm supports min-release-age (see https://docs.npmjs.com/cli/v11/using-npm/changelog#11100-2026-02-11)

I set it to three days in .npmrc which is identical to what we have in our Renovate config