### PR TITLE
Add agent skills installation step to Copilot Setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Setup project for CI run
         run: npm run setup:ci && npm --prefix admin run setup:ci && npm --prefix site run setup:ci
+
+      - name: Install agent skills
+        run: npm run install-agent-skills

--- a/agent-skills.json
+++ b/agent-skills.json
@@ -1,3 +1,3 @@
 {
-    "repos": ["git@github.com:vivid-planet/comet.git"]
+    "repos": ["https://github.com/vivid-planet/comet.git"]
 }


### PR DESCRIPTION
## Summary
Added a new CI workflow step to install agent skills as part of the project setup process.

## Changes
- Added `Install agent skills` step to the copilot-setup-steps workflow that runs `npm run install-agent-skills` after the standard project setup commands
- Change the repo url from "git@github.com:vivid-planet/comet.git" to "https://github.com/vivid-planet/comet.git", to allow read without login (because it's a public repo)

## Details
This step executes after the main project setup (`npm run setup:ci`) and the setup commands for the admin and site packages, ensuring agent skills are installed as part of the complete CI initialization process.

https://claude.ai/code/session_01KnZvJy34TR9zomG4AXR21W