### PR TITLE
Remove site configs generation from `setup:ci` script

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
         "fixtures": "npm run console fixtures --",
         "fixtures:prod": "npm run console:prod fixtures --",
         "lint": "npm run api-generator && run-p -l lint:{eslint,knip,prettier,tsc,api-can-start}",
-        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true dotenv -e ../.env.secrets -e ../.env.local -e ../.env -e ../.env.site-configs -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
+        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=W10= dotenv -e ../.env.secrets -e ../.env.local -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
         "lint:ci": "npm run lint && npm run lint:generated-files-not-modified",
         "lint:eslint": "eslint --max-warnings 0 src/ '**/*.json' --no-warn-ignored",
         "lint:fix": "run-p lint:fix:{eslint,prettier}",

--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
         "fixtures": "npm run console fixtures --",
         "fixtures:prod": "npm run console:prod fixtures --",
         "lint": "npm run api-generator && run-p -l lint:{eslint,knip,prettier,tsc,api-can-start}",
-        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=W10= dotenv -e ../.env.secrets -e ../.env.local -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
+        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=$(echo -n '[]' | base64) dotenv -e ../.env.secrets -e ../.env.local -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
         "lint:ci": "npm run lint && npm run lint:generated-files-not-modified",
         "lint:eslint": "eslint --max-warnings 0 src/ '**/*.json' --no-warn-ignored",
         "lint:fix": "run-p lint:fix:{eslint,prettier}",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "browser:site": "dotenv -- sh -c 'open-cli $SITE_URL'",
         "browser:jaeger": "dotenv -- sh -c 'open-cli http://localhost:$JAEGER_UI_PORT'",
         "install-agent-skills": "npx @comet/cli install-agent-skills",
-        "setup:ci": "npm run create-site-configs-env && npm run setup-project-files",
+        "setup:ci": "npm run setup-project-files",
         "setup:download-oauth2-proxy": "dotenv -- sh -c 'npx @comet/cli download-oauth2-proxy -v $OAUTH2_PROXY_VERSION'"
     },
     "devDependencies": {


### PR DESCRIPTION
Generating the site configs in the root `setup:ci` script (see https://github.com/vivid-planet/comet-starter/pull/1359) broke CI/CD for our internal Starter due to the missing `dotenv` dependency. Fix CI/CD by not generating site configs but mocking them for `lint:api-can-start` instead.

https://claude.ai/code/session_018gjmzWYUNGjhpfpn3ZUyGq