### PR TITLE
Add `BreadcrumbList` JSON-LD in Breadcrumbs

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -48,6 +48,7 @@
                 "npm-run-all2": "^8.0.4",
                 "prettier": "^3.8.3",
                 "sass": "^1.100.0",
+                "schema-dts": "^2.0.0",
                 "stylelint": "^17.12.0",
                 "stylelint-config-standard-scss": "^17.0.0",
                 "typed-scss-modules": "^8.1.1",
@@ -13856,6 +13857,29 @@
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/schema-dts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-2.0.0.tgz",
+            "integrity": "sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "schema-dts-lib": "^1.0.0"
+            }
+        },
+        "node_modules/schema-dts-lib": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/schema-dts-lib/-/schema-dts-lib-1.0.0.tgz",
+            "integrity": "sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
             }
         },
         "node_modules/scroll-into-view-if-needed": {

--- a/site/package.json
+++ b/site/package.json
@@ -71,6 +71,7 @@
         "npm-run-all2": "^8.0.4",
         "prettier": "^3.8.3",
         "sass": "^1.100.0",
+        "schema-dts": "^2.0.0",
         "stylelint": "^17.12.0",
         "stylelint-config-standard-scss": "^17.0.0",
         "typed-scss-modules": "^8.1.1",

--- a/site/src/common/components/breadcrumbs/Breadcrumbs.tsx
+++ b/site/src/common/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { JsonLd } from "@comet/site-nextjs";
 import { SvgUse } from "@src/common/helpers/SvgUse";
 import { PageLayout } from "@src/layout/PageLayout";
 import { createSitePath } from "@src/util/createSitePath";
@@ -9,10 +8,16 @@ import NextLink from "next/link";
 import { useId, useState } from "react";
 import ReactFocusLock from "react-focus-lock";
 import { FormattedMessage } from "react-intl";
-import type { BreadcrumbList, WithContext } from "schema-dts";
+import type { BreadcrumbList, Thing, WithContext } from "schema-dts";
 
 import { type GQLBreadcrumbsFragment } from "./Breadcrumbs.fragment.generated";
 import styles from "./Breadcrumbs.module.scss";
+
+// Escape `</` to prevent closing the surrounding script tag (standard XSS guard for inline JSON-LD).
+const escapeJsonForScriptTag = (json: string): string => json.replace(/</g, "\\u003c");
+const JsonLd = <T extends Thing>({ data }: { data: WithContext<T> }) => (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: escapeJsonForScriptTag(JSON.stringify(data)) }} />
+);
 
 export const Breadcrumbs = ({ scope, name, path, parentNodes }: GQLBreadcrumbsFragment) => {
     const [isExpanded, setIsExpanded] = useState<boolean>(false);

--- a/site/src/common/components/breadcrumbs/Breadcrumbs.tsx
+++ b/site/src/common/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,12 +1,15 @@
 "use client";
+import { JsonLd } from "@comet/site-nextjs";
 import { SvgUse } from "@src/common/helpers/SvgUse";
 import { PageLayout } from "@src/layout/PageLayout";
 import { createSitePath } from "@src/util/createSitePath";
+import { useSiteConfig } from "@src/util/SiteConfigProvider";
 import clsx from "clsx";
 import NextLink from "next/link";
 import { useId, useState } from "react";
 import ReactFocusLock from "react-focus-lock";
 import { FormattedMessage } from "react-intl";
+import type { BreadcrumbList, WithContext } from "schema-dts";
 
 import { type GQLBreadcrumbsFragment } from "./Breadcrumbs.fragment.generated";
 import styles from "./Breadcrumbs.module.scss";
@@ -15,36 +18,86 @@ export const Breadcrumbs = ({ scope, name, path, parentNodes }: GQLBreadcrumbsFr
     const [isExpanded, setIsExpanded] = useState<boolean>(false);
     const listId = useId();
 
+    const baseUrl = useSiteConfig().url;
+    const absoluteUrl = (nodePath: string) => `${baseUrl}${createSitePath({ path: nodePath, scope })}`;
+
+    const breadcrumbList: WithContext<BreadcrumbList> = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: [
+            ...parentNodes.map((node, index) => ({
+                "@type": "ListItem" as const,
+                position: index + 1,
+                name: node.name,
+                item: absoluteUrl(node.path),
+            })),
+            {
+                "@type": "ListItem" as const,
+                position: parentNodes.length + 1,
+                name,
+            },
+        ],
+    };
+
     return (
-        <PageLayout grid className={styles.root}>
-            <button className={styles.mobileHomeButton} onClick={() => setIsExpanded(!isExpanded)} aria-expanded={isExpanded} aria-controls={listId}>
-                {name}
-                <SvgUse
-                    className={clsx(styles.mobileChevron, isExpanded && styles["mobileChevron--expanded"])}
-                    href="/assets/icons/chevron-down.svg#root"
-                    width={16}
-                    height={16}
-                />
-            </button>
-            {parentNodes.length > 0 && (
-                <ReactFocusLock className={clsx(styles.listContainer, isExpanded && styles["listContainer--expanded"])} disabled={!isExpanded}>
-                    <ol className={styles.list} id={listId}>
-                        <li className={styles.mobileNavigationListElements}>
-                            <button className={styles.mobileBackButton} onClick={() => setIsExpanded(false)}>
-                                <SvgUse href="/assets/icons/arrow-left.svg#root" width={16} height={16} color="inherit" />
-                                <FormattedMessage id="header.closeBreadcrumbs" defaultMessage="Close Breadcrumbs" />
-                            </button>
-                        </li>
-                        <li className={clsx(styles.mobileNavigationListElements, styles.linkContainer)} style={{ "--breadcrumb-level": 0 }}>
-                            <NextLink className={styles.link} href={createSitePath({ path: "/", scope })}>
-                                <FormattedMessage id="header.breadcrumbs.home" defaultMessage="Home" />
-                            </NextLink>
-                        </li>
-                        {parentNodes.map((parentNode, index) => (
+        <>
+            <JsonLd data={breadcrumbList} />
+            <PageLayout grid className={styles.root}>
+                <button
+                    className={styles.mobileHomeButton}
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    aria-expanded={isExpanded}
+                    aria-controls={listId}
+                >
+                    {name}
+                    <SvgUse
+                        className={clsx(styles.mobileChevron, isExpanded && styles["mobileChevron--expanded"])}
+                        href="/assets/icons/chevron-down.svg#root"
+                        width={16}
+                        height={16}
+                    />
+                </button>
+                {parentNodes.length > 0 && (
+                    <ReactFocusLock className={clsx(styles.listContainer, isExpanded && styles["listContainer--expanded"])} disabled={!isExpanded}>
+                        <ol className={styles.list} id={listId}>
+                            <li className={styles.mobileNavigationListElements}>
+                                <button className={styles.mobileBackButton} onClick={() => setIsExpanded(false)}>
+                                    <SvgUse href="/assets/icons/arrow-left.svg#root" width={16} height={16} color="inherit" />
+                                    <FormattedMessage id="header.closeBreadcrumbs" defaultMessage="Close Breadcrumbs" />
+                                </button>
+                            </li>
+                            <li className={clsx(styles.mobileNavigationListElements, styles.linkContainer)} style={{ "--breadcrumb-level": 0 }}>
+                                <NextLink className={styles.link} href={createSitePath({ path: "/", scope })}>
+                                    <FormattedMessage id="header.breadcrumbs.home" defaultMessage="Home" />
+                                </NextLink>
+                            </li>
+                            {parentNodes.map((parentNode, index) => (
+                                <li
+                                    key={parentNode.path}
+                                    className={clsx(styles.listElement, isExpanded && styles.linkContainer)}
+                                    style={{ "--breadcrumb-level": index + 1 }}
+                                >
+                                    <SvgUse
+                                        href="/assets/icons/corner-down-right.svg#root"
+                                        className={clsx(styles.mobileCornerDownRightIcon, styles["link--active"])}
+                                        width={16}
+                                        height={16}
+                                    />
+                                    <NextLink
+                                        className={styles.link}
+                                        href={createSitePath({
+                                            path: parentNode.path,
+                                            scope,
+                                        })}
+                                    >
+                                        {parentNode.name}
+                                    </NextLink>
+                                    <SvgUse href="/assets/icons/chevron-down.svg#root" className={styles.chevron} width={16} height={16} />
+                                </li>
+                            ))}
                             <li
-                                key={parentNode.path}
                                 className={clsx(styles.listElement, isExpanded && styles.linkContainer)}
-                                style={{ "--breadcrumb-level": index + 1 }}
+                                style={{ "--breadcrumb-level": parentNodes.length + 1 }}
                             >
                                 <SvgUse
                                     href="/assets/icons/corner-down-right.svg#root"
@@ -53,40 +106,19 @@ export const Breadcrumbs = ({ scope, name, path, parentNodes }: GQLBreadcrumbsFr
                                     height={16}
                                 />
                                 <NextLink
-                                    className={styles.link}
+                                    className={clsx(styles.link, styles["link--active"])}
                                     href={createSitePath({
-                                        path: parentNode.path,
+                                        path: path,
                                         scope,
                                     })}
                                 >
-                                    {parentNode.name}
+                                    {name}
                                 </NextLink>
-                                <SvgUse href="/assets/icons/chevron-down.svg#root" className={styles.chevron} width={16} height={16} />
                             </li>
-                        ))}
-                        <li
-                            className={clsx(styles.listElement, isExpanded && styles.linkContainer)}
-                            style={{ "--breadcrumb-level": parentNodes.length + 1 }}
-                        >
-                            <SvgUse
-                                href="/assets/icons/corner-down-right.svg#root"
-                                className={clsx(styles.mobileCornerDownRightIcon, styles["link--active"])}
-                                width={16}
-                                height={16}
-                            />
-                            <NextLink
-                                className={clsx(styles.link, styles["link--active"])}
-                                href={createSitePath({
-                                    path: path,
-                                    scope,
-                                })}
-                            >
-                                {name}
-                            </NextLink>
-                        </li>
-                    </ol>
-                </ReactFocusLock>
-            )}
-        </PageLayout>
+                        </ol>
+                    </ReactFocusLock>
+                )}
+            </PageLayout>
+        </>
     );
 };


### PR DESCRIPTION
Starter equivalent of https://github.com/vivid-planet/comet/pull/5568

## Description

- Existing `Breadcrumbs` component now renders structured `BreadcrumbList` JSON-LD data using `JsonLd` from `@comet/site-nextjs`
- Added `schema-dts` as a devDependency for typed structured data definitions

---
_Generated by [Claude Code](https://claude.ai/code/session_016qSpyqqKAauVqrhbNEimuf)_