### PR TITLE
Honor IDP_PORT environment variable in dev-oidc-provider config

### DIFF
--- a/dev-oidc-provider.config.mts
+++ b/dev-oidc-provider.config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from "@comet/dev-oidc-provider";
 import { staticUsers } from "./api/src/auth/static-users";
 
 export default defineConfig({
+    port: process.env.IDP_PORT ? Number(process.env.IDP_PORT) : 8080,
     userProvider: () => Object.values(staticUsers),
     client: {
         client_id: process.env.IDP_CLIENT_ID,


### PR DESCRIPTION
The local IDP's port can be set using the `IDP_PORT` environment variable, but the value wasn't used in the dev-oidc-provider's config.

This ports the equivalent change from the Comet Demo to the Starter.

Source PR: vivid-planet/comet#5852

https://claude.ai/code/session_01NY1hcqYB3K6SW5koTVhxjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY1hcqYB3K6SW5koTVhxjv)_