### PR TITLE
Redirect to main domain if host matches with pattern or additional domains

### DIFF
--- a/site/src/middleware/redirectToMainHost.ts
+++ b/site/src/middleware/redirectToMainHost.ts
@@ -32,7 +32,9 @@ export function withRedirectToMainHostMiddleware(middleware: CustomMiddleware) {
                 getSiteConfigs().find((siteConfig) => matchesHostWithAdditionalDomain(siteConfig, host)) ||
                 getSiteConfigs().find((siteConfig) => matchesHostWithPattern(siteConfig, host));
             if (redirectSiteConfig) {
-                return NextResponse.redirect(redirectSiteConfig.url + request.nextUrl.pathname + request.nextUrl.search, { status: 301 });
+                return NextResponse.redirect(`https://${redirectSiteConfig.domains.main}${request.nextUrl.pathname}${request.nextUrl.search}`, {
+                    status: 301,
+                });
             }
 
             return NextResponse.json({ error: `Cannot resolve domain: ${host}` }, { status: 404 });


### PR DESCRIPTION
Source PR: https://github.com/vivid-planet/comet/pull/4655

## Description

The current behaviour is that `getSiteConfigForHost()` returns only the siteConfig if the exact domain is passed. If not, a redirect occurs — if a preliminary domain is set, it will be used as redirect target.

This PR makes the redirect always occur to the main host. The preliminary host is still used for the preview in the Admin.

## Summary

- `site/src/middleware/redirectToMainHost.ts`: The redirect target was previously built using `redirectSiteConfig.url + pathname + search`, which could produce incorrect URLs when a preliminary domain was set. It now always redirects to `https://${redirectSiteConfig.domains.main}${pathname}${search}` to ensure the redirect always targets the canonical main domain.

## Skipped

Nothing was skipped — the single changed file maps 1:1 to the starter.

---
_Synced from [vivid-planet/comet#4655](https://github.com/vivid-planet/comet/pull/4655)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwTgihUBoKMcyNx95UDzBB)_