### PR TITLE
Replace dot navigation in media gallery

### DIFF
--- a/site/src/common/blocks/MediaGalleryBlock.module.scss
+++ b/site/src/common/blocks/MediaGalleryBlock.module.scss
@@ -32,44 +32,6 @@
 }
 
 .swiper {
-    :global(.swiper-pagination) {
-        width: auto;
-        position: absolute;
-        bottom: 35px;
-        left: 0;
-        gap: var(--spacing-s400);
-
-        @media (min-width: $breakpoint-sm) {
-            bottom: var(--spacing-s100);
-            left: auto;
-            right: 0;
-        }
-
-        :global(.swiper-pagination-bullet) {
-            color: var(--media-gallery-dot-navigation-default);
-            margin-right: var(--spacing-s400);
-            margin-left: 0;
-
-            &:hover {
-                background-color: var(--media-gallery-dot-navigation-hover);
-            }
-
-            @media (min-width: $breakpoint-sm) {
-                bottom: var(--spacing-s100);
-                margin-left: var(--spacing-s400);
-                margin-right: 0;
-            }
-        }
-
-        :global(.swiper-pagination-bullet-active) {
-            background-color: var(--media-gallery-dot-navigation-active);
-
-            &:hover {
-                background-color: var(--media-gallery-dot-navigation-active-hover);
-            }
-        }
-    }
-
     .mediaCaption {
         opacity: 0;
         transition: opacity 0.3s linear 0s;
@@ -142,5 +104,17 @@
         &--next {
             right: -48px;
         }
+    }
+}
+
+.customPagination {
+    position: absolute;
+    bottom: 35px;
+    left: 0;
+
+    @media (min-width: $breakpoint-sm) {
+        bottom: var(--spacing-s100);
+        left: auto;
+        right: 0;
     }
 }

--- a/site/src/common/blocks/MediaGalleryBlock.tsx
+++ b/site/src/common/blocks/MediaGalleryBlock.tsx
@@ -8,8 +8,8 @@ import { Typography } from "@src/common/components/Typography";
 import { PageLayout } from "@src/layout/PageLayout";
 import clsx from "clsx";
 import { useEffect, useRef, useState } from "react";
-import { useIntl } from "react-intl";
-import { Navigation, Pagination } from "swiper/modules";
+import { FormattedMessage, useIntl } from "react-intl";
+import { Navigation } from "swiper/modules";
 import { SwiperSlide } from "swiper/react";
 import { type Swiper as SwiperClass } from "swiper/types";
 
@@ -55,8 +55,7 @@ export const MediaGalleryBlock = withPreview(
                     className={styles.swiper}
                     slidesPerView={1}
                     slidesPerGroup={1}
-                    modules={[Pagination, Navigation]}
-                    pagination={{ clickable: true }}
+                    modules={[Navigation]}
                     navigation={{ prevEl: prevButtonRef.current, nextEl: nextButtonRef.current }}
                     longSwipesRatio={0.1}
                     threshold={3}
@@ -77,6 +76,13 @@ export const MediaGalleryBlock = withPreview(
                         </SwiperSlide>
                     ))}
                 </BasicSwiper>
+                <Typography variant="paragraph300" className={styles.customPagination} role="status" aria-live="polite" aria-atomic="true">
+                    <FormattedMessage
+                        id="mediaGalleryBlock.pagination"
+                        defaultMessage="{current} of {total}"
+                        values={{ current: activeItem + 1, total: data.items.blocks.length }}
+                    />
+                </Typography>
                 <button
                     ref={nextButtonRef}
                     className={clsx(styles.navigationButton, styles["navigationButton--next"])}


### PR DESCRIPTION
Source PR: https://github.com/vivid-planet/comet/pull/5030

## Description

Instead of displaying the native swiper pagination using bullet points, the current page number out of the total number of pages should be used (e.g. 1 of 12).

- Remove pagination module and its styling
- Add and style page numbers instead according to design
- Add aria attributes for screen readers

## Summary

- `site/src/common/blocks/MediaGalleryBlock.tsx`: Removed `Pagination` swiper module and replaced the bullet-dot pagination with a counter showing current page out of total (e.g. "1 of 12"). Added `FormattedMessage` for the pagination text and appropriate ARIA attributes (`role="status"`, `aria-live="polite"`, `aria-atomic="true"`).
- `site/src/common/blocks/MediaGalleryBlock.module.scss`: Removed `.swiper-pagination` and bullet-point styles; added `.customPagination` class to position the new text counter.

## Screenshots

Desktop:
<img width="1183" height="621" alt="Screenshot 2026-01-12 at 17 02 45" src="https://github.com/user-attachments/assets/45d4e385-a482-4874-8535-5d7fac12441c"/>

Mobile:
<img width="446" height="884" alt="Screenshot 2026-01-12 at 17 03 05" src="https://github.com/user-attachments/assets/dfa1aadc-ab43-40e2-ba82-52902413bf01"/>

## Skipped

Nothing was skipped — both changed files map 1:1 to the starter.

---
_Synced from [vivid-planet/comet#5030](https://github.com/vivid-planet/comet/pull/5030)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwTgihUBoKMcyNx95UDzBB)_