### PR TITLE
Admin: Use ADMIN_PORT variable consistently

### DIFF
--- a/admin/server/index.js
+++ b/admin/server/index.js
@@ -6,7 +6,7 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 const expressStaticGzip = require("express-static-gzip");
 
 const app = express();
-const port = process.env.APP_PORT ?? 3000;
+const port = process.env.ADMIN_PORT ?? 3000;
 const host = process.env.SERVER_HOST ?? "localhost";
 
 let indexFile = fs.readFileSync("./build/index.html", "utf8");


### PR DESCRIPTION
Source PR: https://github.com/vivid-planet/comet/pull/5094

## Summary

- `admin/server/index.js`: Changed `process.env.APP_PORT` to `process.env.ADMIN_PORT` for consistency with the `API_PORT` / `SITE_PORT` naming convention.

## Skipped

Nothing was skipped — the single changed file maps 1:1 to the starter.

---
_Synced from [vivid-planet/comet#5094](https://github.com/vivid-planet/comet/pull/5094)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwTgihUBoKMcyNx95UDzBB)_