### PR TITLE
Configure API to use PostgreSQL TEXT for string columns

### DIFF
--- a/api/src/db/ormconfig.ts
+++ b/api/src/db/ormconfig.ts
@@ -17,6 +17,7 @@ export const ormConfig = createOrmConfig(
         debug: false,
         discovery: {
             getMappedType(type: string, platform) {
+                // Map all string types to TEXT instead of VARCHAR
                 if (type === "string") {
                     return Type.getType(TextType);
                 }

--- a/api/src/db/ormconfig.ts
+++ b/api/src/db/ormconfig.ts
@@ -1,5 +1,5 @@
 import { createMigrationsList, createOrmConfig } from "@comet/cms-api";
-import { EntityCaseNamingStrategy } from "@mikro-orm/core";
+import { EntityCaseNamingStrategy, TextType, Type } from "@mikro-orm/core";
 import { defineConfig } from "@mikro-orm/postgresql";
 import path from "path";
 
@@ -15,6 +15,14 @@ export const ormConfig = createOrmConfig(
         },
         namingStrategy: EntityCaseNamingStrategy,
         debug: false,
+        discovery: {
+            getMappedType(type: string, platform) {
+                if (type === "string") {
+                    return Type.getType(TextType);
+                }
+                return platform.getDefaultMappedType(type);
+            },
+        },
         connect: process.env.MIKRO_ORM_NO_CONNECT !== "true",
         migrations: {
             tableName: "Migrations",


### PR DESCRIPTION
Source PR: https://github.com/vivid-planet/comet/pull/5160

## Description

MikroORM defaults to `varchar(255)` for string properties. This changes the project to use PostgreSQL `text` type instead.

**Implementation:**
- Uses MikroORM's built-in `TextType` via `Type.getType(TextType)` (see https://mikro-orm.io/docs/configuration#adjusting-default-type-mapping)
- Configured via `discovery.getMappedType` in `api/src/db/ormconfig.ts` with proper fallback to `platform.getDefaultMappedType()` for non-string types

```typescript
// api/src/db/ormconfig.ts
import { TextType, Type } from "@mikro-orm/core";

defineConfig({
    discovery: {
        getMappedType(type: string, platform) {
            if (type === "string") {
                return Type.getType(TextType);
            }
            return platform.getDefaultMappedType(type);
        },
    },
    // ...
})
```

All new string properties will automatically use `text` without explicit `columnType` specification.

**No migration needed:** The starter's existing string columns (`scope_domain`, `scope_language`, etc.) already use `type: "text"` explicitly in the entity definitions. This change is purely forward-looking — it ensures any future string property that omits an explicit type will default to `text` instead of `varchar(255)`.

## Summary

- `api/src/db/ormconfig.ts`: Added `discovery.getMappedType` to map all MikroORM `string` types to PostgreSQL `TEXT` instead of the default `VARCHAR(255)`.

## Skipped

- `demo/api/src/db/migrations/Migration20260213103747.ts` — Demo-specific migration converting Demo tables (`Product`, `News`, `Manufacturer`, etc.). No equivalent tables exist in the starter, and no migration is needed since existing string columns already use `text` explicitly.

---
_Synced from [vivid-planet/comet#5160](https://github.com/vivid-planet/comet/pull/5160)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwTgihUBoKMcyNx95UDzBB)_