### PR TITLE
Ignore .claude/worktrees/ to skip them during local linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 
 .agents/skills
 .claude/skills
+.claude/worktrees/


### PR DESCRIPTION
Source PR: https://github.com/vivid-planet/comet/pull/5684

## Description

Add `.claude/worktrees/` to `.gitignore` so files inside Claude Code worktrees are not picked up by local linting runs.

![Screenshot 2026-05-21 at 13 22 12](https://github.com/user-attachments/assets/83118758-4b3a-4c29-b2dd-9d949b982835)

## Summary

- `.gitignore`: Added `.claude/worktrees/` so files inside Claude Code worktrees are not picked up by `npm run lint` locally.

## Skipped

Nothing was skipped — the single changed file maps 1:1 to the starter.

---
_Synced from [vivid-planet/comet#5684](https://github.com/vivid-planet/comet/pull/5684)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwTgihUBoKMcyNx95UDzBB)_