### PR TITLE
ci: Verify lockfiles are up to date after install

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,41 @@
+name: "Setup"
+description: "Set up Node.js, install dependencies, and verify lockfiles are up to date"
+
+inputs:
+  setup-ci:
+    description: "Run the project's CI setup scripts"
+    default: "true"
+  build:
+    description: "Build all packages"
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Use Node.js 24.x
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        cache: "npm"
+        cache-dependency-path: "**/package-lock.json"
+        registry-url: "https://registry.npmjs.org"
+
+    - name: Install dependencies
+      shell: bash
+      run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix admin/server ci && npm --prefix site ci && npm --prefix create-app ci
+      env:
+        NPM_CONFIG_STRICT_PEER_DEPS: true
+
+    - name: Verify lockfiles are up to date
+      shell: bash
+      run: git diff --exit-code -- ':(glob)**/package-lock.json'
+
+    - name: Setup project for CI run
+      if: ${{ inputs.setup-ci == 'true' }}
+      shell: bash
+      run: npm run setup:ci && npm --prefix admin run setup:ci && npm --prefix site run setup:ci
+
+    - name: Build
+      if: ${{ inputs.build == 'true' }}
+      shell: bash
+      run: npm run build && npm --prefix create-app run build

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,14 +1,6 @@
 name: "Setup"
 description: "Set up Node.js, install dependencies, and verify lockfiles are up to date"
 
-inputs:
-  setup-ci:
-    description: "Run the project's CI setup scripts"
-    default: "true"
-  build:
-    description: "Build all packages"
-    default: "false"
-
 runs:
   using: "composite"
   steps:
@@ -31,11 +23,5 @@ runs:
       run: git diff --exit-code -- ':(glob)**/package-lock.json'
 
     - name: Setup project for CI run
-      if: ${{ inputs.setup-ci == 'true' }}
       shell: bash
       run: npm run setup:ci && npm --prefix admin run setup:ci && npm --prefix site run setup:ci
-
-    - name: Build
-      if: ${{ inputs.build == 'true' }}
-      shell: bash
-      run: npm run build && npm --prefix create-app run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,8 +31,9 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-        with:
-          build: "true"
 
       - name: Lint
         run: npm run lint:ci && npm --prefix api run lint:ci && npm --prefix admin run lint:ci && npm --prefix site run lint:ci && npm --prefix create-app run lint
+
+      - name: Build
+        run: npm run build && npm --prefix create-app run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,27 +29,10 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-      - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+      - name: Setup
+        uses: ./.github/actions/setup
         with:
-          node-version: 24
-          cache: "npm"
-          cache-dependency-path: "**/package-lock.json"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix admin/server ci && npm --prefix site ci && npm --prefix create-app ci
-        env:
-          NPM_CONFIG_STRICT_PEER_DEPS: true
-
-      - name: Verify lockfiles are up to date
-        run: git diff --exit-code -- ':(glob)**/package-lock.json'
-
-      - name: Setup project for CI run
-        run: npm run setup:ci && npm --prefix admin run setup:ci && npm --prefix site run setup:ci
+          build: "true"
 
       - name: Lint
         run: npm run lint:ci && npm --prefix api run lint:ci && npm --prefix admin run lint:ci && npm --prefix site run lint:ci && npm --prefix create-app run lint
-
-      - name: Build
-        run: npm run build && npm --prefix create-app run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix site ci && npm --prefix create-app ci
+        run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix admin/server ci && npm --prefix site ci && npm --prefix create-app ci
         env:
           NPM_CONFIG_STRICT_PEER_DEPS: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,6 +42,9 @@ jobs:
         env:
           NPM_CONFIG_STRICT_PEER_DEPS: true
 
+      - name: Verify lockfiles are up to date
+        run: git diff --exit-code -- ':(glob)**/package-lock.json'
+
       - name: Setup project for CI run
         run: npm run setup:ci && npm --prefix admin run setup:ci && npm --prefix site run setup:ci
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,24 +29,8 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-      - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "npm"
-          cache-dependency-path: "**/package-lock.json"
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix admin/server ci && npm --prefix site ci
-        env:
-          NPM_CONFIG_STRICT_PEER_DEPS: true
-
-      - name: Verify lockfiles are up to date
-        run: git diff --exit-code -- ':(glob)**/package-lock.json'
-
-      - name: Setup project for CI run
-        run: npm run setup:ci && npm --prefix admin run setup:ci && npm --prefix site run setup:ci
+      - name: Setup
+        uses: ./.github/actions/setup
 
       - name: Test
         run: npm run test:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix site ci
+        run: npm ci && npm --prefix api ci && npm --prefix admin ci && npm --prefix admin/server ci && npm --prefix site ci
         env:
           NPM_CONFIG_STRICT_PEER_DEPS: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ jobs:
         env:
           NPM_CONFIG_STRICT_PEER_DEPS: true
 
+      - name: Verify lockfiles are up to date
+        run: git diff --exit-code -- ':(glob)**/package-lock.json'
+
       - name: Setup project for CI run
         run: npm run setup:ci && npm --prefix admin run setup:ci && npm --prefix site run setup:ci
 

--- a/admin/server/package.json
+++ b/admin/server/package.json
@@ -5,8 +5,7 @@
         "express": "^5.2.1",
         "express-static-gzip": "^3.0.1",
         "helmet": "^8.2.0",
-        "http-proxy-middleware": "^4.0.0",
-        "is-odd": "^3.0.1"
+        "http-proxy-middleware": "^4.0.0"
     },
     "engines": {
         "node": "24"

--- a/admin/server/package.json
+++ b/admin/server/package.json
@@ -5,7 +5,8 @@
         "express": "^5.2.1",
         "express-static-gzip": "^3.0.1",
         "helmet": "^8.2.0",
-        "http-proxy-middleware": "^4.0.0"
+        "http-proxy-middleware": "^4.0.0",
+        "is-odd": "^3.0.1"
     },
     "engines": {
         "node": "24"


### PR DESCRIPTION
## Problem

A `package.json` change that adds a dependency without updating the lockfile could pass CI undetected:

- The `admin/server` service was **completely absent** from the CI install steps, so its lockfile was never validated at all.
- Even after adding it, `npm ci` alone does **not** catch the issue: `admin`'s `postinstall` hook runs `cd server && npm install`, and `npm install` (unlike `npm ci`) **silently rewrites** `admin/server/package-lock.json` to add the missing dependency. By the time `npm --prefix admin/server ci` runs, the lockfile is already back in sync, so it passes.

## Solution

Add `admin/server` to the **Install dependencies** step, and add a dedicated **Verify lockfiles are up to date** step right after install in both `lint.yml` and `test.yml`:

```yaml
- name: Verify lockfiles are up to date
  run: git diff --exit-code -- ':(glob)**/package-lock.json'
```

Because the install step (via the postinstall `npm install`) modifies any out-of-sync lockfile in the working tree, `git diff --exit-code` reliably catches it and fails the run. This covers all lockfiles: root, `api`, `admin`, `admin/server`, `site`, and `create-app`.

## Verification

Confirmed end-to-end by temporarily adding a dependency to `admin/server/package.json` without updating the lockfile:

- Before the verify step: the **Test** job stayed green (the postinstall masked the out-of-sync lockfile from `npm ci`).
- After the verify step: the **Test** job failed at *Verify lockfiles are up to date*, with the diff showing `is-odd` written into `admin/server/package-lock.json`.

The temporary dependency was then reverted.

## References

- Jira: [COM-3009](https://vivid-planet.atlassian.net/browse/COM-3009) (epic: [COM-260](https://vivid-planet.atlassian.net/browse/COM-260))

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tga83toTr33QRZi4vYbRAP)_

[COM-3009]: https://vivid-planet.atlassian.net/browse/COM-3009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ