### PR TITLE
Use mirror.gcr.io registry for all Docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: mirror.gcr.io/library/postgres:16
     pull_policy: weekly
     tty: true
     volumes:
@@ -15,7 +15,7 @@ services:
       - postgres
 
   imgproxy:
-    image: darthsim/imgproxy:v4
+    image: mirror.gcr.io/darthsim/imgproxy:v4
     pull_policy: weekly
     volumes:
       - ./api/uploads:/uploads:ro
@@ -36,7 +36,7 @@ services:
       AWS_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}
 
   jaeger:
-    image: jaegertracing/all-in-one:1
+    image: mirror.gcr.io/jaegertracing/all-in-one:1
     pull_policy: weekly
     ports:
       - "127.0.0.1:${JAEGER_UI_PORT}:16686"
@@ -46,7 +46,7 @@ services:
       COLLECTOR_OTLP_HTTP_HOST_PORT: 0.0.0.0:4318
 
 #  valkey:
-#    image: valkey/valkey:9
+#    image: mirror.gcr.io/valkey/valkey:9
 #    pull_policy: weekly
 #    command: valkey-server --maxmemory 256M --maxmemory-policy allkeys-lru --loglevel warning --requirepass ${VALKEY_PASSWORD}
 #    ports:


### PR DESCRIPTION
Synced from vivid-planet/comet#5908.

Use `mirror.gcr.io` for Docker images in `docker-compose.yml` to avoid problems with Docker Hub rate limiting.

Previously, when running locally, this is usually not a problem because images get cached, and if it is a problem you can log into Docker and have a per-user rate limit rather than a per-IP rate limit.

But when running Docker in a cloud agent, download happens more often and the IP is shared with other users. And login is not easily possible.

## Changes applied

Updated image names in `docker-compose.yml`:
- `postgres:16` → `mirror.gcr.io/library/postgres:16`
- `darthsim/imgproxy:v4` → `mirror.gcr.io/darthsim/imgproxy:v4`
- `jaegertracing/all-in-one:1` → `mirror.gcr.io/jaegertracing/all-in-one:1`
- `valkey/valkey:9` → `mirror.gcr.io/valkey/valkey:9` (currently commented out)

## Skipped

- `axllent/mailpit` — not present in comet-starter's `docker-compose.yml`
- The source change was to `docker-compose.yml` at the repo root (outside `/demo`), but comet-starter has a clear equivalent file at the same path with the same services.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrG18ant8eYvpPMENdaeQ8)_