### PR TITLE
Fix auto assigning

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -3,7 +3,7 @@ addAssignees: author
 addReviewers: true
 
 reviewers:
-  - johnnyomair
+  - VPS-Obi
 
 skipKeywords:
   - Merge main into next

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,10 @@
+name: "Auto Assign"
+on:
+    pull_request:
+        types: [opened, ready_for_review]
+
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: kentaro-m/auto-assign-action@v2.0.2

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,10 +1,10 @@
 name: "Auto Assign"
 on:
-    pull_request:
-        types: [opened, ready_for_review]
+  pull_request:
+    types: [opened, ready_for_review]
 
 jobs:
-    auto-assign:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: kentaro-m/auto-assign-action@v2.0.2
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.2


### PR DESCRIPTION
Synced from vivid-planet/comet#5918.

Auto assigning via the GitHub app is broken (see https://github.com/kentaro-m/auto-assign/issues/295). Using the GitHub action should work.

**Changes applied:**
- `.github/auto_assign.yml`: Updated reviewer from `johnnyomair` to `VPS-Obi`
- `.github/workflows/auto-assign.yml`: Added new workflow to trigger auto-assign via GitHub Action (`kentaro-m/auto-assign-action@v2.0.2`) instead of the broken GitHub App

**Notes:**
- Both changed files are outside `/demo` but have clear equivalents in comet-starter (the repo already had `.github/auto_assign.yml` and no `auto-assign.yml` workflow).
- Nothing was skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7S25AVvpVf8YiNoVCeCeg)_