### PR TITLE
Remove CORS configuration from API

### DIFF
--- a/.env
+++ b/.env
@@ -41,7 +41,6 @@ AUTHPROXY_URL=http://${DEV_DOMAIN:-localhost}:${AUTHPROXY_PORT}
 API_PORT=4000
 API_URL=$ADMIN_URL/api
 API_URL_INTERNAL=http://localhost:$API_PORT/api
-CORS_ALLOWED_ORIGIN="^http:\/\/(localhost|.*\.dev\.vivid-planet\.cloud|192\.168\.\d{1,3}\.\d{1,3}):\d{2,4}"
 BASIC_AUTH_SYSTEM_USER_PASSWORD=aPasswordWith16Characters
 ACL_ALL_PERMISSIONS_EMAILS=admin@customer.com
 ACL_ALL_PERMISSIONS_DOMAINS=vivid-planet.com

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -67,12 +67,6 @@ export class AppModule {
                             return error;
                         },
                         context: ({ req }: { req: Request }) => ({ ...req }),
-                        cors: {
-                            origin: config.corsAllowedOrigin,
-                            methods: ["GET", "POST"],
-                            credentials: false,
-                            maxAge: 600,
-                        },
                         useGlobalPrefix: true,
                         // See https://docs.nestjs.com/graphql/other-features#execute-enhancers-at-the-field-resolver-level
                         fieldResolverEnhancers: ["guards", "interceptors", "filters"] as Enhancer[],

--- a/api/src/config/config.ts
+++ b/api/src/config/config.ts
@@ -16,7 +16,6 @@ export function createConfig(processEnv: NodeJS.ProcessEnv) {
         serverHost: envVars.SERVER_HOST ?? "localhost",
         apiUrl: envVars.API_URL,
         apiPort: envVars.API_PORT,
-        corsAllowedOrigin: new RegExp(envVars.CORS_ALLOWED_ORIGIN),
         auth: {
             systemUserPassword: envVars.BASIC_AUTH_SYSTEM_USER_PASSWORD,
             idpClientId: envVars.IDP_CLIENT_ID,

--- a/api/src/config/environment-variables.ts
+++ b/api/src/config/environment-variables.ts
@@ -62,9 +62,6 @@ export class EnvironmentVariables {
     API_PORT: number;
 
     @IsString()
-    CORS_ALLOWED_ORIGIN: string;
-
-    @IsString()
     IMGPROXY_SALT: string;
 
     @IsString()

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -29,13 +29,6 @@ async function bootstrap(): Promise<void> {
 
     app.setGlobalPrefix("api");
 
-    app.enableCors({
-        origin: config.corsAllowedOrigin,
-        methods: ["GET", "POST"],
-        credentials: false,
-        maxAge: 600,
-    });
-
     app.useGlobalFilters(new ExceptionFilter(config.debug));
     app.useGlobalPipes(
         new ValidationPipe({


### PR DESCRIPTION
Synced from vivid-planet/comet#5906.

## Summary

The authproxy routes the api and admin to the same domain, so cross-origin requests no longer occur and CORS handling is unnecessary. Remove the `enableCors` call, the GraphQL `cors` option, and the now-unused `CORS_ALLOWED_ORIGIN` environment variable.

## Changes applied

| comet path | comet-starter path | Change |
|---|---|---|
| `.env` | `.env` | Removed `CORS_ALLOWED_ORIGIN` variable |
| `demo/api/src/main.ts` | `api/src/main.ts` | Removed `app.enableCors(...)` call |
| `demo/api/src/app.module.ts` | `api/src/app.module.ts` | Removed GraphQL `cors` option |
| `demo/api/src/config/config.ts` | `api/src/config/config.ts` | Removed `corsAllowedOrigin` from config object |
| `demo/api/src/config/environment-variables.ts` | `api/src/config/environment-variables.ts` | Removed `CORS_ALLOWED_ORIGIN` env var declaration |

## Skipped / out of scope

None — all 5 changed files in the source PR map directly to comet-starter equivalents and were fully applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGjSmkhbnc4SU4yc7P7KcH)_