### PR TITLE
Add BigInt number mapping to codegen

### DIFF
--- a/admin/codegen.ts
+++ b/admin/codegen.ts
@@ -31,6 +31,7 @@ const config: CodegenConfig = {
                     Date: "string",
                     LocalDate: "string",
                     ID: "string",
+                    BigInt: "number",
                 }),
                 typesPrefix: "GQL",
             },
@@ -53,6 +54,7 @@ const config: CodegenConfig = {
                     Date: "string",
                     LocalDate: "string",
                     ID: "string",
+                    BigInt: "number",
                 }),
                 typesPrefix: "GQL",
                 skipDocumentsValidation: {

--- a/site/codegen.ts
+++ b/site/codegen.ts
@@ -16,6 +16,7 @@ const pluginConfig = {
         DateTime: "string",
         LocalDate: "string",
         ID: "string",
+        BigInt: "number",
     }),
     typesPrefix: "GQL",
 };


### PR DESCRIPTION
Map the GraphQL `BigInt` scalar to the JavaScript `number` type in the generated TypeScript code for both `admin` and `site`.

This mirrors the change in comet ([vivid-planet/comet#5925](https://github.com/vivid-planet/comet/pull/5925)), where the `size` field of `DamFile` and `FileUpload` was switched from `Int` to `BigInt` to support files larger than ~2.1 GB (the max of a 32-bit signed integer). Without a scalar mapping, codegen would emit `BigInt` as `any`.

## Changes

- `admin/codegen.ts`: add `BigInt: "number"` to both scalar maps (base types and near-operation-file configs)
- `site/codegen.ts`: add `BigInt: "number"` to the shared `pluginConfig` scalar map

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyDjkWEzsJzAYVmM7tVHwi

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyDjkWEzsJzAYVmM7tVHwi)_