### PR TITLE
Fix `lint:api-can-start` crashing on macOS due to non-portable `echo -n`

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
         "fixtures": "npm run console fixtures --",
         "fixtures:prod": "npm run console:prod fixtures --",
         "lint": "npm run api-generator && run-p -l lint:{eslint,knip,prettier,tsc,api-can-start}",
-        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=$(printf '%s' '[]' | base64) dotenv -e ../.env.secrets -e ../.env.local -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
+        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=$(echo '[]' | base64) dotenv -e ../.env.secrets -e ../.env.local -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
         "lint:ci": "npm run lint && npm run lint:generated-files-not-modified",
         "lint:eslint": "eslint --max-warnings 0 src/ '**/*.json' --no-warn-ignored",
         "lint:fix": "run-p lint:fix:{eslint,prettier}",

--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
         "fixtures": "npm run console fixtures --",
         "fixtures:prod": "npm run console:prod fixtures --",
         "lint": "npm run api-generator && run-p -l lint:{eslint,knip,prettier,tsc,api-can-start}",
-        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=$(echo -n '[]' | base64) dotenv -e ../.env.secrets -e ../.env.local -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
+        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=$(printf '%s' '[]' | base64) dotenv -e ../.env.secrets -e ../.env.local -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
         "lint:ci": "npm run lint && npm run lint:generated-files-not-modified",
         "lint:eslint": "eslint --max-warnings 0 src/ '**/*.json' --no-warn-ignored",
         "lint:fix": "run-p lint:fix:{eslint,prettier}",


### PR DESCRIPTION
## Problem

Running `npm run lint` (or `lint:api-can-start`) on macOS crashes with:

```
SyntaxError: No number after minus sign in JSON at position 1
  at JSON.parse (<anonymous>)
  at .../api/src/config/environment-variables.ts:123
```

## Root cause

The script seeds an empty config via `PRIVATE_SITE_CONFIGS=$(echo -n '[]' | base64)`. `echo -n` is not POSIX-portable:

- On **Linux CI** `/bin/sh` is `dash`, which strips `-n` → encodes `[]` ✅
- On **macOS** `/bin/sh` is bash in POSIX mode, where the `echo` builtin does **not** treat `-n` as a flag → encodes the literal `-n []` ❌

So `PRIVATE_SITE_CONFIGS` decodes to `-n []`, and the `@Transform` doing `JSON.parse("-n []")` throws. CI stayed green, hiding the bug from anyone not on macOS.

## Fix

Drop the non-portable `-n` flag and rely on `JSON.parse` ignoring trailing whitespace:

```diff
-PRIVATE_SITE_CONFIGS=$(echo -n '[]' | base64)
+PRIVATE_SITE_CONFIGS=$(echo '[]' | base64)
```

`echo '[]'` produces `[]\n` in every shell (`dash`, `bash`, `zsh`, macOS `/bin/sh`), and `JSON.parse("[]\n")` parses fine. `echo` stays a recognized shell builtin, so `lint:knip` is happy too (an earlier attempt using `printf` was flagged by knip as an unlisted binary).

Verified locally: `lint:api-can-start` boots the API and prints `--help` on macOS, and `lint:knip` reports no unlisted binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)