### PR TITLE
Add `BreadcrumbList` JSON-LD in Demo

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -48,6 +48,7 @@
                 "npm-run-all2": "^9.0.2",
                 "prettier": "^3.9.1",
                 "sass": "^1.101.0",
+                "schema-dts": "^2.0.0",
                 "stylelint": "^17.14.0",
                 "stylelint-config-standard-scss": "^17.0.0",
                 "typed-scss-modules": "^8.1.1",
@@ -14300,6 +14301,29 @@
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/schema-dts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-2.0.0.tgz",
+            "integrity": "sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "schema-dts-lib": "^1.0.0"
+            }
+        },
+        "node_modules/schema-dts-lib": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/schema-dts-lib/-/schema-dts-lib-1.0.0.tgz",
+            "integrity": "sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
             }
         },
         "node_modules/scroll-into-view-if-needed": {

--- a/site/package.json
+++ b/site/package.json
@@ -71,6 +71,7 @@
         "npm-run-all2": "^9.0.2",
         "prettier": "^3.9.1",
         "sass": "^1.101.0",
+        "schema-dts": "^2.0.0",
         "stylelint": "^17.14.0",
         "stylelint-config-standard-scss": "^17.0.0",
         "typed-scss-modules": "^8.1.1",

--- a/site/src/common/components/breadcrumbs/Breadcrumbs.tsx
+++ b/site/src/common/components/breadcrumbs/Breadcrumbs.tsx
@@ -2,49 +2,107 @@
 import { SvgUse } from "@src/common/helpers/SvgUse";
 import { PageLayout } from "@src/layout/PageLayout";
 import { createSitePath } from "@src/util/createSitePath";
+import { useSiteConfig } from "@src/util/SiteConfigProvider";
 import clsx from "clsx";
 import NextLink from "next/link";
 import { useId, useState } from "react";
 import ReactFocusLock from "react-focus-lock";
 import { FormattedMessage } from "react-intl";
+import type { BreadcrumbList, Thing, WithContext } from "schema-dts";
 
 import { type GQLBreadcrumbsFragment } from "./Breadcrumbs.fragment.generated";
 import styles from "./Breadcrumbs.module.scss";
+
+// Escape `</` to prevent closing the surrounding script tag (standard XSS guard for inline JSON-LD).
+const escapeJsonForScriptTag = (json: string): string => json.replace(/</g, "\\u003c");
+const JsonLd = <T extends Thing>({ data }: { data: WithContext<T> }) => (
+    <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: escapeJsonForScriptTag(JSON.stringify(data)) }} />
+);
 
 export const Breadcrumbs = ({ scope, name, path, parentNodes }: GQLBreadcrumbsFragment) => {
     const [isExpanded, setIsExpanded] = useState<boolean>(false);
     const listId = useId();
 
+    const baseUrl = useSiteConfig().url;
+    const absoluteUrl = (nodePath: string) => `${baseUrl}${createSitePath({ path: nodePath, scope })}`;
+
+    const breadcrumbList: WithContext<BreadcrumbList> = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: [
+            ...parentNodes.map((node, index) => ({
+                "@type": "ListItem" as const,
+                position: index + 1,
+                name: node.name,
+                item: absoluteUrl(node.path),
+            })),
+            {
+                "@type": "ListItem" as const,
+                position: parentNodes.length + 1,
+                name,
+            },
+        ],
+    };
+
     return (
-        <PageLayout grid className={styles.root}>
-            <button className={styles.mobileHomeButton} onClick={() => setIsExpanded(!isExpanded)} aria-expanded={isExpanded} aria-controls={listId}>
-                {name}
-                <SvgUse
-                    className={clsx(styles.mobileChevron, isExpanded && styles["mobileChevron--expanded"])}
-                    href="/assets/icons/chevron-down.svg#root"
-                    width={16}
-                    height={16}
-                />
-            </button>
-            {parentNodes.length > 0 && (
-                <ReactFocusLock className={clsx(styles.listContainer, isExpanded && styles["listContainer--expanded"])} disabled={!isExpanded}>
-                    <ol className={styles.list} id={listId}>
-                        <li className={styles.mobileNavigationListElements}>
-                            <button className={styles.mobileBackButton} onClick={() => setIsExpanded(false)}>
-                                <SvgUse href="/assets/icons/arrow-left.svg#root" width={16} height={16} color="inherit" />
-                                <FormattedMessage id="header.closeBreadcrumbs" defaultMessage="Close Breadcrumbs" />
-                            </button>
-                        </li>
-                        <li className={clsx(styles.mobileNavigationListElements, styles.linkContainer)} style={{ "--breadcrumb-level": 0 }}>
-                            <NextLink className={styles.link} href={createSitePath({ path: "/", scope })}>
-                                <FormattedMessage id="header.breadcrumbs.home" defaultMessage="Home" />
-                            </NextLink>
-                        </li>
-                        {parentNodes.map((parentNode, index) => (
+        <>
+            <JsonLd data={breadcrumbList} />
+            <PageLayout grid className={styles.root}>
+                <button
+                    className={styles.mobileHomeButton}
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    aria-expanded={isExpanded}
+                    aria-controls={listId}
+                >
+                    {name}
+                    <SvgUse
+                        className={clsx(styles.mobileChevron, isExpanded && styles["mobileChevron--expanded"])}
+                        href="/assets/icons/chevron-down.svg#root"
+                        width={16}
+                        height={16}
+                    />
+                </button>
+                {parentNodes.length > 0 && (
+                    <ReactFocusLock className={clsx(styles.listContainer, isExpanded && styles["listContainer--expanded"])} disabled={!isExpanded}>
+                        <ol className={styles.list} id={listId}>
+                            <li className={styles.mobileNavigationListElements}>
+                                <button className={styles.mobileBackButton} onClick={() => setIsExpanded(false)}>
+                                    <SvgUse href="/assets/icons/arrow-left.svg#root" width={16} height={16} color="inherit" />
+                                    <FormattedMessage id="header.closeBreadcrumbs" defaultMessage="Close Breadcrumbs" />
+                                </button>
+                            </li>
+                            <li className={clsx(styles.mobileNavigationListElements, styles.linkContainer)} style={{ "--breadcrumb-level": 0 }}>
+                                <NextLink className={styles.link} href={createSitePath({ path: "/", scope })}>
+                                    <FormattedMessage id="header.breadcrumbs.home" defaultMessage="Home" />
+                                </NextLink>
+                            </li>
+                            {parentNodes.map((parentNode, index) => (
+                                <li
+                                    key={parentNode.path}
+                                    className={clsx(styles.listElement, isExpanded && styles.linkContainer)}
+                                    style={{ "--breadcrumb-level": index + 1 }}
+                                >
+                                    <SvgUse
+                                        href="/assets/icons/corner-down-right.svg#root"
+                                        className={clsx(styles.mobileCornerDownRightIcon, styles["link--active"])}
+                                        width={16}
+                                        height={16}
+                                    />
+                                    <NextLink
+                                        className={styles.link}
+                                        href={createSitePath({
+                                            path: parentNode.path,
+                                            scope,
+                                        })}
+                                    >
+                                        {parentNode.name}
+                                    </NextLink>
+                                    <SvgUse href="/assets/icons/chevron-down.svg#root" className={styles.chevron} width={16} height={16} />
+                                </li>
+                            ))}
                             <li
-                                key={parentNode.path}
                                 className={clsx(styles.listElement, isExpanded && styles.linkContainer)}
-                                style={{ "--breadcrumb-level": index + 1 }}
+                                style={{ "--breadcrumb-level": parentNodes.length + 1 }}
                             >
                                 <SvgUse
                                     href="/assets/icons/corner-down-right.svg#root"
@@ -53,40 +111,19 @@ export const Breadcrumbs = ({ scope, name, path, parentNodes }: GQLBreadcrumbsFr
                                     height={16}
                                 />
                                 <NextLink
-                                    className={styles.link}
+                                    className={clsx(styles.link, styles["link--active"])}
                                     href={createSitePath({
-                                        path: parentNode.path,
+                                        path: path,
                                         scope,
                                     })}
                                 >
-                                    {parentNode.name}
+                                    {name}
                                 </NextLink>
-                                <SvgUse href="/assets/icons/chevron-down.svg#root" className={styles.chevron} width={16} height={16} />
                             </li>
-                        ))}
-                        <li
-                            className={clsx(styles.listElement, isExpanded && styles.linkContainer)}
-                            style={{ "--breadcrumb-level": parentNodes.length + 1 }}
-                        >
-                            <SvgUse
-                                href="/assets/icons/corner-down-right.svg#root"
-                                className={clsx(styles.mobileCornerDownRightIcon, styles["link--active"])}
-                                width={16}
-                                height={16}
-                            />
-                            <NextLink
-                                className={clsx(styles.link, styles["link--active"])}
-                                href={createSitePath({
-                                    path: path,
-                                    scope,
-                                })}
-                            >
-                                {name}
-                            </NextLink>
-                        </li>
-                    </ol>
-                </ReactFocusLock>
-            )}
-        </PageLayout>
+                        </ol>
+                    </ReactFocusLock>
+                )}
+            </PageLayout>
+        </>
     );
 };


### PR DESCRIPTION
Starter equivalent of https://github.com/vivid-planet/comet/pull/5568

## Description

- Existing `Breadcrumbs` component now renders structured `BreadcrumbList` JSON-LD data
- Added `schema-dts` as a devDependency for typed structured data definitions

### Note on translation

The source PR (comet#5568) uses the new `JsonLd` component from `@comet/site-nextjs`. That component was only added in `@comet/site-nextjs@9.0.0-beta.4` and hasn't been released on the stable 8.x line yet, which is what comet-starter is pinned to (`8.24.5`). Since a prior attempt at this sync (#1490) predates that source PR being merged and was closed for that reason, this PR reimplements the small `JsonLd` script-tag helper locally in `Breadcrumbs.tsx` (same escaping approach as `@comet/site-nextjs`'s implementation) so the change works against the currently pinned package version. Once comet-starter upgrades to a `@comet/site-nextjs` release that exports `JsonLd`, this local helper can be swapped for the package export.

## Further information

- Related: #1490 (closed — was created before comet#5568 was merged)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DDje7wT48iPouMNUMPoWr1)_