### PR TITLE
Load @faker-js/faker lazily in fixtures

### DIFF
--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -4,6 +4,21 @@ import { defineConfig, globalIgnores } from "eslint/config";
 const config = defineConfig([
     globalIgnores(["src/db/migrations/**", "dist/**", "src/**/*.generated.ts", "src/**/generated", "block-meta.json", "package-lock.json", "uploads/**"]),
     ...eslintConfigNestJs,
+    {
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    paths: [
+                        {
+                            name: "@faker-js/faker",
+                            message: "Import faker from '@src/db/fixtures/faker' instead, which lazily loads @faker-js/faker so it isn't pulled into memory on every API startup.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
 ]);
 
 export default config;

--- a/api/src/db/fixtures/faker.ts
+++ b/api/src/db/fixtures/faker.ts
@@ -1,0 +1,24 @@
+type Faker = (typeof import("@faker-js/faker"))["faker"];
+
+let instance: Faker | undefined;
+
+function getFaker(): Faker {
+    if (!instance) {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        instance = (require("@faker-js/faker") as typeof import("@faker-js/faker")).faker;
+    }
+    return instance;
+}
+
+// @faker-js/faker is heavy (~33 MB resident) and only needed when fixtures are generated via
+// the CLI. Importing it eagerly in the fixture services pulled it into memory on every API
+// startup. This proxy defers the actual `require` until the first property access, so importing
+// a fixture service (e.g. during normal API startup) no longer loads faker.
+export const faker: Faker = new Proxy({} as Faker, {
+    get(_target, property) {
+        const value = getFaker()[property as keyof Faker];
+        // Bind top-level methods (e.g. faker.seed()) to the real instance so their `this` is correct.
+        // Sub-namespaces (faker.person, faker.image, …) are objects and are returned as-is.
+        return typeof value === "function" ? value.bind(getFaker()) : value;
+    },
+});

--- a/api/src/db/fixtures/fixtures.command.ts
+++ b/api/src/db/fixtures/fixtures.command.ts
@@ -1,9 +1,9 @@
 import { DependenciesService } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { CreateRequestContext, MikroORM } from "@mikro-orm/core";
 import { Inject, Logger } from "@nestjs/common";
 import { Config } from "@src/config/config";
 import { CONFIG } from "@src/config/config.module";
+import { faker } from "@src/db/fixtures/faker";
 import { MultiBar, Options, Presets } from "cli-progress";
 import { Command, CommandRunner } from "nest-commander";
 

--- a/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/layout/accordion-block-fixture.service.ts
@@ -1,8 +1,8 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { AccordionBlock } from "@src/common/blocks/accordion.block";
 import { AccordionContentBlock, AccordionItemBlock, AccordionItemTitleHtmlTag } from "@src/common/blocks/accordion-item.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { BlockFixture } from "../block-fixture";
 import { StandaloneCallToActionListBlockFixtureService } from "../navigation/standalone-call-to-action-list-block-fixture.service";

--- a/api/src/db/fixtures/generators/blocks/layout/columns-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/layout/columns-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { ColumnsBlock, ColumnsContentBlock } from "@src/documents/pages/blocks/columns.block";
 
 import { BlockFixture } from "../block-fixture";

--- a/api/src/db/fixtures/generators/blocks/layout/content-group-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/layout/content-group-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { BackgroundColor as ContentGroupBackgroundColor, ContentBlock, ContentGroupBlock } from "@src/documents/pages/blocks/content-group.block";
 
 import { BlockFixture } from "../block-fixture";

--- a/api/src/db/fixtures/generators/blocks/layout/space-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/layout/space-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { SpaceBlock, Spacing } from "@src/common/blocks/space.block";
+import { faker } from "@src/db/fixtures/faker";
 
 @Injectable()
 export class SpaceBlockFixtureService {

--- a/api/src/db/fixtures/generators/blocks/media/dam-image-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/media/dam-image-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { DamImageBlock, ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { PixelImageBlockFixtureService } from "./pixel-image-block-fixture.service";
 import { SvgImageBlockFixtureService } from "./svg-image-block-fixture.service";

--- a/api/src/db/fixtures/generators/blocks/media/dam-video-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/media/dam-video-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { DamVideoBlock, ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { VideoFixtureService } from "../../video-fixture.service";
 import { PixelImageBlockFixtureService } from "./pixel-image-block-fixture.service";

--- a/api/src/db/fixtures/generators/blocks/media/media-block.fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/media/media-block.fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { MediaBlock } from "@src/common/blocks/media.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { DamImageBlockFixtureService } from "./dam-image-block-fixture.service";
 import { DamVideoBlockFixtureService } from "./dam-video-block-fixture.service";

--- a/api/src/db/fixtures/generators/blocks/media/media-gallery-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/media/media-gallery-block-fixture.service.ts
@@ -1,8 +1,8 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { MediaGalleryBlock, MediaGalleryListBlock } from "@src/common/blocks/media-gallery.block";
 import { MediaGalleryItemBlock } from "@src/common/blocks/media-gallery-item.block";
+import { faker } from "@src/db/fixtures/faker";
 import { MediaAspectRatios } from "@src/util/mediaAspectRatios";
 
 import { MediaBlockFixtureService } from "./media-block.fixture.service";

--- a/api/src/db/fixtures/generators/blocks/media/pixel-image-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/media/pixel-image-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps, FocalPoint, ImageCropAreaInput, PixelImageBlock } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { ImageFixtureService } from "../../image-fixture.service";
 

--- a/api/src/db/fixtures/generators/blocks/media/standalone-media-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/media/standalone-media-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { StandaloneMediaBlock } from "@src/common/blocks/standalone-media.block";
+import { faker } from "@src/db/fixtures/faker";
 import { MediaAspectRatios } from "@src/util/mediaAspectRatios";
 
 import { MediaBlockFixtureService } from "./media-block.fixture.service";

--- a/api/src/db/fixtures/generators/blocks/media/vimeo-video-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/media/vimeo-video-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps, VimeoVideoBlock } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { PixelImageBlockFixtureService } from "./pixel-image-block-fixture.service";
 

--- a/api/src/db/fixtures/generators/blocks/media/youtube-video-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/media/youtube-video-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps, YouTubeVideoBlock } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 import { PixelImageBlockFixtureService } from "./pixel-image-block-fixture.service";
 

--- a/api/src/db/fixtures/generators/blocks/navigation/anchor-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/navigation/anchor-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { AnchorBlock, ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 
 @Injectable()
 export class AnchorBlockFixtureService {

--- a/api/src/db/fixtures/generators/blocks/navigation/call-to-action-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/navigation/call-to-action-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { CallToActionBlock, Variant as CallToActionVariant } from "@src/common/blocks/call-to-action.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { TextLinkBlockFixtureService } from "./text-link-block-fixture.service";
 

--- a/api/src/db/fixtures/generators/blocks/navigation/call-to-action-list-block.service.ts
+++ b/api/src/db/fixtures/generators/blocks/navigation/call-to-action-list-block.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { CallToActionListBlock } from "@src/common/blocks/call-to-action-list.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { CallToActionBlockFixtureService } from "./call-to-action-block-fixture.service";
 

--- a/api/src/db/fixtures/generators/blocks/navigation/link-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/navigation/link-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { LinkBlock } from "@src/common/blocks/link.block";
+import { faker } from "@src/db/fixtures/faker";
 
 const urls = ["https://vivid-planet.com/", "https://github.com/", "https://gitlab.com", "https://stackoverflow.com/"];
 

--- a/api/src/db/fixtures/generators/blocks/navigation/link-list-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/navigation/link-list-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { LinkListBlock } from "@src/common/blocks/link-list.block";
+import { faker } from "@src/db/fixtures/faker";
 import { TextLinkBlockFixtureService } from "@src/db/fixtures/generators/blocks/navigation/text-link-block-fixture.service";
 
 @Injectable()

--- a/api/src/db/fixtures/generators/blocks/navigation/standalone-call-to-action-list-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/navigation/standalone-call-to-action-list-block-fixture.service.ts
@@ -1,10 +1,10 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
 import { Injectable } from "@nestjs/common";
-import { faker } from "@src/db/fixtures/faker";
 import {
     Alignment as StandaloneCallToActionListBlockAlignment,
     StandaloneCallToActionListBlock,
 } from "@src/common/blocks/standalone-call-to-action-list.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { CallToActionListBlockFixtureService } from "./call-to-action-list-block.service";
 

--- a/api/src/db/fixtures/generators/blocks/navigation/standalone-call-to-action-list-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/navigation/standalone-call-to-action-list-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import {
     Alignment as StandaloneCallToActionListBlockAlignment,
     StandaloneCallToActionListBlock,

--- a/api/src/db/fixtures/generators/blocks/navigation/text-link-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/navigation/text-link-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { TextLinkBlock } from "@src/common/blocks/text-link.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { LinkBlockFixtureService } from "./link-block-fixture.service";
 

--- a/api/src/db/fixtures/generators/blocks/stage/basic-stage-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/stage/basic-stage-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { Alignment as BasicStageBlockAlignment, BasicStageBlock } from "@src/documents/pages/blocks/basic-stage.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";

--- a/api/src/db/fixtures/generators/blocks/teaser/billboard-teaser-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/teaser/billboard-teaser-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { BillboardTeaserBlock } from "@src/documents/pages/blocks/billboard-teaser.block";
 
 import { MediaBlockFixtureService } from "../media/media-block.fixture.service";

--- a/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/teaser/teaser-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { TeaserBlock } from "@src/documents/pages/blocks/teaser.block";
 import { TeaserItemBlock, TeaserItemTitleHtmlTag } from "@src/documents/pages/blocks/teaser-item.block";
 

--- a/api/src/db/fixtures/generators/blocks/text-and-content/heading-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/text-and-content/heading-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { HeadingBlock, HeadlineTag } from "@src/common/blocks/heading.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { RichTextBlockFixtureService } from "./rich-text-block-fixture.service";
 

--- a/api/src/db/fixtures/generators/blocks/text-and-content/key-facts-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/text-and-content/key-facts-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { KeyFactsBlock } from "@src/documents/pages/blocks/key-facts.block";
 import { KeyFactsItemBlock } from "@src/documents/pages/blocks/key-facts-item.block";
 

--- a/api/src/db/fixtures/generators/blocks/text-and-content/rich-text-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/text-and-content/rich-text-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { RichTextBlock } from "@src/common/blocks/rich-text.block";
+import { faker } from "@src/db/fixtures/faker";
 
 @Injectable()
 export class RichTextBlockFixtureService {

--- a/api/src/db/fixtures/generators/blocks/text-and-content/standalone-heading-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/text-and-content/standalone-heading-block-fixture.service.ts
@@ -1,7 +1,7 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
 import { StandaloneHeadingBlock, TextAlignment } from "@src/common/blocks/standalone-heading.block";
+import { faker } from "@src/db/fixtures/faker";
 
 import { HeadingBlockFixtureService } from "./heading-block-fixture.service";
 

--- a/api/src/db/fixtures/generators/document-generator.service.ts
+++ b/api/src/db/fixtures/generators/document-generator.service.ts
@@ -1,7 +1,7 @@
 import { PageTreeNodeInterface, PageTreeNodeVisibility, PageTreeService } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
 import { SeoBlock } from "@src/documents/pages/blocks/seo.block";
 import { StageBlock } from "@src/documents/pages/blocks/stage.block";

--- a/api/src/db/fixtures/generators/image-fixture.service.ts
+++ b/api/src/db/fixtures/generators/image-fixture.service.ts
@@ -1,7 +1,7 @@
 import { createFileUploadInputFromUrl, FileInterface, FilesService } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import * as fs from "fs/promises";
 import path from "path";
 

--- a/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/page-content-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { PageContentBlock } from "@src/documents/pages/blocks/page-content.block";
 
 import { BlockFixture } from "./blocks/block-fixture";

--- a/api/src/db/fixtures/generators/seo-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/seo-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps, SitemapPageChangeFrequency, SitemapPagePriority } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { SeoBlock } from "@src/documents/pages/blocks/seo.block";
 
 import { PixelImageBlockFixtureService } from "./blocks/media/pixel-image-block-fixture.service";

--- a/api/src/db/fixtures/generators/stage-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/stage-block-fixture.service.ts
@@ -1,6 +1,6 @@
 import { ExtractBlockInputFactoryProps } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import { StageBlock } from "@src/documents/pages/blocks/stage.block";
 
 import { BasicStageBlockFixtureService } from "./blocks/stage/basic-stage-block-fixture.service";

--- a/api/src/db/fixtures/generators/video-fixture.service.ts
+++ b/api/src/db/fixtures/generators/video-fixture.service.ts
@@ -1,7 +1,7 @@
 import { createFileUploadInputFromUrl, FileInterface, FilesService } from "@comet/cms-api";
-import { faker } from "@faker-js/faker";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { Injectable } from "@nestjs/common";
+import { faker } from "@src/db/fixtures/faker";
 import * as fs from "fs/promises";
 import path from "path";
 


### PR DESCRIPTION
Starter equivalent of https://github.com/vivid-planet/comet/pull/5940

## Description

`@faker-js/faker` (~33 MB resident) is only needed when fixtures are generated via the CLI, but was imported eagerly in the fixture services, loading it into memory on every API startup. The imports now go through a proxy module that defers the `require` until faker is first used, so normal API startup no longer loads it.

- Added `api/src/db/fixtures/faker.ts`, a proxy module that lazily `require`s `@faker-js/faker` on first property access
- Updated all fixture services under `api/src/db/fixtures/` to import `faker` from `@src/db/fixtures/faker` instead of `@faker-js/faker` directly

## Skipped / not applicable

The source PR also touched fixture files for blocks/features that don't exist in comet-starter (these are demo-only): `image.generator.ts`, `layout-block-fixture.service.ts`, `full-width-image-block-fixture.service.ts`, `slider-fixture.service.ts`, `table-block-fixture.service.ts`, `text-image-block-fixture.service.ts`, `product-list-block.fixture.ts`, `many-images-test-page-fixture.service.ts`, `news-fixture.service.ts`, `products-fixture.service.ts`, and `redirects-fixture.service.ts`. These were skipped since comet-starter has no equivalent files.

## Note

I wasn't able to run `lint:fix`/`tsc` in this environment (no `node_modules` installed, and the pinned Node version — 24 — wasn't available), so please double check import ordering/formatting on review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DDje7wT48iPouMNUMPoWr1)_