### PR TITLE
Remove site-configs-env setup from dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "scripts": {
         "create-site-configs-env": "dotenv -e .env.secrets -e .env.local -e .env -- npx @comet/cli inject-site-configs -f site-configs/site-configs.ts -i .env.site-configs.tpl -o .env.site-configs --base64",
-        "dev": "npm run create-site-configs-env && dev-pm start",
+        "dev": "dev-pm start",
         "dev:auth-proxy": "dotenv -- ./node_modules/.bin/oauth2-proxy --cookie-secret=$(head -c 16 /dev/random | base64)",
         "dev:auth-provider": "dotenv -- dev-oidc-provider",
         "setup-project-files": "node setup-project-files.js",


### PR DESCRIPTION
install.sh already runs create-site-configs-env during setup, so
re-running it on every npm run dev was redundant and slowed down
startup, especially when injecting secrets from 1Password.

https://claude.ai/code/session_01QNH4xPnqEnUUFA4EcpMyzE