### PR TITLE
Revert "Remove CORS configuration from API"

### DIFF
--- a/.env
+++ b/.env
@@ -41,6 +41,7 @@ AUTHPROXY_URL=http://${DEV_DOMAIN:-localhost}:${AUTHPROXY_PORT}
 API_PORT=4000
 API_URL=$ADMIN_URL/api
 API_URL_INTERNAL=http://localhost:$API_PORT/api
+CORS_ALLOWED_ORIGIN="^http:\/\/(localhost|.*\.dev\.vivid-planet\.cloud|192\.168\.\d{1,3}\.\d{1,3}):\d{2,4}"
 BASIC_AUTH_SYSTEM_USER_PASSWORD=aPasswordWith16Characters
 ACL_ALL_PERMISSIONS_EMAILS=admin@customer.com
 ACL_ALL_PERMISSIONS_DOMAINS=vivid-planet.com

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -67,6 +67,12 @@ export class AppModule {
                             return error;
                         },
                         context: ({ req }: { req: Request }) => ({ ...req }),
+                        cors: {
+                            origin: config.corsAllowedOrigin,
+                            methods: ["GET", "POST"],
+                            credentials: false,
+                            maxAge: 600,
+                        },
                         useGlobalPrefix: true,
                         // See https://docs.nestjs.com/graphql/other-features#execute-enhancers-at-the-field-resolver-level
                         fieldResolverEnhancers: ["guards", "interceptors", "filters"] as Enhancer[],

--- a/api/src/config/config.ts
+++ b/api/src/config/config.ts
@@ -16,6 +16,7 @@ export function createConfig(processEnv: NodeJS.ProcessEnv) {
         serverHost: envVars.SERVER_HOST ?? "localhost",
         apiUrl: envVars.API_URL,
         apiPort: envVars.API_PORT,
+        corsAllowedOrigin: new RegExp(envVars.CORS_ALLOWED_ORIGIN),
         auth: {
             systemUserPassword: envVars.BASIC_AUTH_SYSTEM_USER_PASSWORD,
             idpClientId: envVars.IDP_CLIENT_ID,

--- a/api/src/config/environment-variables.ts
+++ b/api/src/config/environment-variables.ts
@@ -62,6 +62,9 @@ export class EnvironmentVariables {
     API_PORT: number;
 
     @IsString()
+    CORS_ALLOWED_ORIGIN: string;
+
+    @IsString()
     IMGPROXY_SALT: string;
 
     @IsString()

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -29,6 +29,13 @@ async function bootstrap(): Promise<void> {
 
     app.setGlobalPrefix("api");
 
+    app.enableCors({
+        origin: config.corsAllowedOrigin,
+        methods: ["GET", "POST"],
+        credentials: false,
+        maxAge: 600,
+    });
+
     app.useGlobalFilters(new ExceptionFilter(config.debug));
     app.useGlobalPipes(
         new ValidationPipe({


### PR DESCRIPTION
Starter equivalent of https://github.com/vivid-planet/comet/pull/5963, which reverts https://github.com/vivid-planet/comet/pull/5906.

Reverts #1541 (the starter equivalent of #5906).

## Description

We do have cross-origin requests in one situation: a block preview running in the site (on a preview domain) can use a block-loader that runs client-side and loads data directly from the api. That request is cross-origin, so the api must send CORS headers for it.

## Changes applied

| comet path | comet-starter path | Change |
|---|---|---|
| `.env` | `.env` | Re-add `CORS_ALLOWED_ORIGIN` variable |
| `demo/api/src/main.ts` | `api/src/main.ts` | Re-add `app.enableCors(...)` call |
| `demo/api/src/app.module.ts` | `api/src/app.module.ts` | Re-add GraphQL `cors` option |
| `demo/api/src/config/config.ts` | `api/src/config/config.ts` | Re-add `corsAllowedOrigin` to config object |
| `demo/api/src/config/environment-variables.ts` | `api/src/config/environment-variables.ts` | Re-add `CORS_ALLOWED_ORIGIN` env var declaration |

## Skipped / not applicable

None — all 5 changed files in the source PR map directly to comet-starter equivalents and were fully applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S4osU88ZzchxrsmEaZzkfu)_