### PR TITLE
Update Comet to stable v9 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,11 @@ node_modules
 .env.site-configs
 coverage
 
+.agents/rules
 .agents/skills
+.claude/rules
 .claude/settings.local.json
 .claude/skills
 .claude/worktrees/
+.cursor/rules
+.github/instructions

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -10,9 +10,9 @@
             "hasInstallScript": true,
             "dependencies": {
                 "@apollo/client": "^3.14.1",
-                "@comet/admin": "9.0.0-beta.5",
-                "@comet/admin-icons": "9.0.0-beta.5",
-                "@comet/cms-admin": "9.0.0-beta.5",
+                "@comet/admin": "9.1.0",
+                "@comet/admin-icons": "9.1.0",
+                "@comet/cms-admin": "9.1.0",
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.1",
                 "@fontsource-variable/roboto-flex": "^5.2.8",
@@ -38,9 +38,9 @@
                 "react-router-dom": "^5.3.4"
             },
             "devDependencies": {
-                "@comet/admin-generator": "9.0.0-beta.5",
-                "@comet/cli": "9.0.0-beta.5",
-                "@comet/eslint-config": "9.0.0-beta.5",
+                "@comet/admin-generator": "9.1.0",
+                "@comet/cli": "9.1.0",
+                "@comet/eslint-config": "9.1.0",
                 "@formatjs/cli": "^6.16.11",
                 "@graphql-codegen/add": "^7.0.1",
                 "@graphql-codegen/cli": "^7.1.3",
@@ -433,14 +433,14 @@
             }
         },
         "node_modules/@comet/admin": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/admin/-/admin-9.0.0-beta.5.tgz",
-            "integrity": "sha512-Pfx6kUoGl78mJfo4URwmB5O+y7uZw4ka/4lSJvUsyTSI6zl75KWUvOFrDDtwrqWh0hH7k67dyCUN9zoRW8Acyg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/admin/-/admin-9.1.0.tgz",
+            "integrity": "sha512-xN5axyeLH/erBhfbrsZHMLDbtlJoY4x+iEcCIKHlphOQmamnws2iILuZbqyucOLVaiTgIuNcG5JiVoOJZHpy8A==",
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@comet/admin-icons": "9.0.0-beta.5",
+                "@comet/admin-icons": "9.1.0",
                 "@mui/utils": "^7.3.11",
-                "date-fns": "^4.2.1",
+                "date-fns": "^4.4.0",
                 "exceljs": "^4.4.0",
                 "final-form-set-field-data": "^1.0.2",
                 "http-status-codes": "^2.3.0",
@@ -489,15 +489,15 @@
             }
         },
         "node_modules/@comet/admin-date-time": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/admin-date-time/-/admin-date-time-9.0.0-beta.5.tgz",
-            "integrity": "sha512-y1gRsr7gup9XtmahuTw+ls/irJao8Fg6tdNwikIogbJUHqq5drW4KwauEaMHJLVvhP2O8g1SkfAzWZ47dozbmA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/admin-date-time/-/admin-date-time-9.1.0.tgz",
+            "integrity": "sha512-7x/4eCT/Nw9qRpZHGlnvUX22+I3c4N0MK7ULmIo1z8yNl+jzNVXlBMMFdFcD8uZgBQIIMBPHZRh1O74BGLe5ng==",
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@comet/admin": "9.0.0-beta.5",
-                "@comet/admin-icons": "9.0.0-beta.5",
+                "@comet/admin": "9.1.0",
+                "@comet/admin-icons": "9.1.0",
                 "@mui/utils": "^7.3.11",
-                "date-fns": "^4.2.1",
+                "date-fns": "^4.4.0",
                 "react-date-range": "^2.0.1"
             },
             "engines": {
@@ -512,15 +512,15 @@
             }
         },
         "node_modules/@comet/admin-generator": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/admin-generator/-/admin-generator-9.0.0-beta.5.tgz",
-            "integrity": "sha512-nN5fuVIAsNtYnRyG0+CCzq0kR7MR365CLzCx1yOlWJkaaoa5nTvB22cCVzyWkQUh7KL4JlCdFsaVvYYqA3b/4A==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/admin-generator/-/admin-generator-9.1.0.tgz",
+            "integrity": "sha512-Z2bQCnOB4OtCOvANgGhxjrldyY9qZdaNFe2RFydLjuW9uxm4l999cLERhzwBt179ZvOltdsGJu3twz0uTVwEJQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@comet/admin": "9.0.0-beta.5",
-                "@comet/admin-icons": "9.0.0-beta.5",
-                "@comet/cms-admin": "9.0.0-beta.5",
+                "@comet/admin": "9.1.0",
+                "@comet/admin-icons": "9.1.0",
+                "@comet/cms-admin": "9.1.0",
                 "@graphql-tools/graphql-file-loader": "^7.5.17",
                 "@graphql-tools/load": "^7.8.14",
                 "@mui/material": "^7.3.11",
@@ -528,7 +528,7 @@
                 "change-case": "^4.1.2",
                 "commander": "^9.5.0",
                 "glob": "^11.1.0",
-                "graphql": "^16.14.0",
+                "graphql": "^16.14.2",
                 "jiti": "^2.7.0",
                 "object-path": "^0.11.8",
                 "pluralize": "^8.0.0",
@@ -568,9 +568,9 @@
             }
         },
         "node_modules/@comet/admin-icons": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/admin-icons/-/admin-icons-9.0.0-beta.5.tgz",
-            "integrity": "sha512-Bx90h3k7P6zmD7ueaFoMDmgwOfB366ACHBz6bISDvBbvipwdnKMGemE5C+xmUcKspeibrOjZkpYdvY0LvcK2/w==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/admin-icons/-/admin-icons-9.1.0.tgz",
+            "integrity": "sha512-8L5tgfd1uRbmQaoWgOI1gh/dIeF4kI72hqIB03P5lqgBC2JkDVZG2h4cqFafZZqIEalI2XzGWKl/8GER5fbw/g==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "use-constant": "^2.0.0",
@@ -586,13 +586,13 @@
             }
         },
         "node_modules/@comet/admin-rte": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/admin-rte/-/admin-rte-9.0.0-beta.5.tgz",
-            "integrity": "sha512-myd1yl/iVyEdoPtQr5ZPAG/EyKnUlKd9CRKBqS0QE5RQpJa1dacvdTs55d6WM+YPOLq/qmz6FkW3gIH2NrhS5Q==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/admin-rte/-/admin-rte-9.1.0.tgz",
+            "integrity": "sha512-vO8HZz9HWXI0lSyUeTfj8MbQQWFjy4xr77QiM3kPR86ytLqEa8Se5m/VBPYxWFa3Ls72hnuAp/2uOhH6DlLlvg==",
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@comet/admin": "9.0.0-beta.5",
-                "@comet/admin-icons": "9.0.0-beta.5",
+                "@comet/admin": "9.1.0",
+                "@comet/admin-icons": "9.1.0",
                 "detect-browser": "^5.3.0",
                 "draft-js-export-html": "^1.4.1",
                 "draft-js-import-html": "^1.4.1",
@@ -613,9 +613,9 @@
             }
         },
         "node_modules/@comet/cli": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/cli/-/cli-9.0.0-beta.5.tgz",
-            "integrity": "sha512-pf+4R978IX5sGLCOKhZjtV+KomDryjFHdNjVjDOjiqlW2cxwBtTSxkYfGSPfvoeIYvFN42V3Bq/WEJjub1W5BQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/cli/-/cli-9.1.0.tgz",
+            "integrity": "sha512-70F1IdhcaLh9bktn8c3FU+luG0ANIS5ntAunQyukGds0QeqW3sIPHhXlceaqUojY05uKCEFoPq3iiWQhTqzlog==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -632,15 +632,15 @@
             }
         },
         "node_modules/@comet/cms-admin": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/cms-admin/-/cms-admin-9.0.0-beta.5.tgz",
-            "integrity": "sha512-Q3viiEClCeunT4/VepWXqBf1zbPEltMj6lUSqhd1yyKnfJTc8YQtpa/h8s9u/9HZ9d1SwGyyukXSJuEW6dlO/w==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/cms-admin/-/cms-admin-9.1.0.tgz",
+            "integrity": "sha512-G+Uxyr8Qb3J9+96k65p3AslqtOegPU2XGnZX+gjtevqtiapzLBp31OhkTfg/3k/tcKOdC2gkAUtEQYznOIqY+g==",
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@comet/admin": "9.0.0-beta.5",
-                "@comet/admin-date-time": "9.0.0-beta.5",
-                "@comet/admin-icons": "9.0.0-beta.5",
-                "@comet/admin-rte": "9.0.0-beta.5",
+                "@comet/admin": "9.1.0",
+                "@comet/admin-date-time": "9.1.0",
+                "@comet/admin-icons": "9.1.0",
+                "@comet/admin-rte": "9.1.0",
                 "@tiptap/core": "^3.22.3",
                 "@tiptap/extension-heading": "^3.22.3",
                 "@tiptap/extension-paragraph": "^3.22.3",
@@ -651,10 +651,10 @@
                 "@tiptap/starter-kit": "^3.22.3",
                 "change-case": "^4.1.2",
                 "class-validator": "^0.14.3",
-                "date-fns": "^4.2.1",
+                "date-fns": "^4.4.0",
                 "final-form-arrays": "^3.1.0",
                 "final-form-set-field-touched": "^1.0.1",
-                "js-cookie": "^3.0.7",
+                "js-cookie": "^3.0.8",
                 "lodash.escaperegexp": "^4.1.2",
                 "lodash.isequal": "^4.5.0",
                 "mime-db": "^1.54.0",
@@ -722,18 +722,18 @@
             }
         },
         "node_modules/@comet/eslint-config": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/eslint-config/-/eslint-config-9.0.0-beta.5.tgz",
-            "integrity": "sha512-KbVm8A1TKAmNkwxUpwZZKJETTm230MWlMEMkLrWNiaWZFyX0zIzZ4a51kM9LIj/WqkF2Zs0kE+zfApUezmFGeg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/eslint-config/-/eslint-config-9.1.0.tgz",
+            "integrity": "sha512-gQK2nm7W8FBhLG4bnJfQXf3ufMB6D+qRya9m/3Q0jT7VJB+kA8bPhnvacH0ocQqNxeq0K/lVmkGFPHfjiiYMdw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@calm/eslint-plugin-react-intl": "^1.4.1",
-                "@comet/eslint-plugin": "9.0.0-beta.5",
+                "@comet/eslint-plugin": "9.1.0",
                 "@eslint/eslintrc": "^3.3.5",
                 "@eslint/js": "^9.39.4",
                 "@graphql-eslint/eslint-plugin": "^4.4.0",
-                "@next/eslint-plugin-next": "^16.2.6",
+                "@next/eslint-plugin-next": "^16.2.10",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-formatjs": "^5.4.2",
                 "eslint-plugin-import": "^2.32.0",
@@ -746,7 +746,7 @@
                 "eslint-plugin-unused-imports": "^4.4.1",
                 "globals": "^15.15.0",
                 "npm-run-all2": "^8.0.4",
-                "typescript-eslint": "^8.59.3"
+                "typescript-eslint": "^8.62.1"
             },
             "engines": {
                 "node": ">=22.0.0"
@@ -862,9 +862,9 @@
             }
         },
         "node_modules/@comet/eslint-plugin": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/eslint-plugin/-/eslint-plugin-9.0.0-beta.5.tgz",
-            "integrity": "sha512-XYuj83Q/WHrRnkUULeUo50jV13DZ+Xa2n7c5leatOdhSMj/xRDx7LjjMP21t2OHf4N75o8Fy9uyd38umbdcQFg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/eslint-plugin/-/eslint-plugin-9.1.0.tgz",
+            "integrity": "sha512-pkB8M69ITwDJC541WB0Z6wSZxfm05PqhQkzbCSWRFvd3Rl/QbGjLlt/Vy/lg7gZf35ZomVgHUeW0O5Vzevn6yQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -3715,9 +3715,9 @@
             }
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "16.2.7",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.7.tgz",
-            "integrity": "sha512-VbS+QgMHqvIDMTIqD2xMBKK1otIpdAUKA8VLHFwR9h6OfU/mOm7w/69nQcvdmI8hCk99Wr2AsGLn/PJ/tMHw1w==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
+            "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5451,48 +5451,48 @@
             }
         },
         "node_modules/@tiptap/core": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.26.0.tgz",
-            "integrity": "sha512-7jTed/RirIVsp+lLdLvGzGqF3EBGpnGHGYKOwz6t28V2BIJLAFdUhfEVdWie7xPxQNWK0TP+fPlsqZS0vxfHBg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.3.tgz",
+            "integrity": "sha512-TJj5929M96C1KlH796wS8MywfHDh49RhmakOyzyMMc9pFmRj9UXi1gj0TCXgsZtjEOG7B+m/DRvNOvnuvR9kmg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-blockquote": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.26.0.tgz",
-            "integrity": "sha512-57accpka9affjiJRjP2LMNCDJDTMjTvO23RJCxtP43sp9cTIZ7YZnyDfRxCINTRBNK0X4o4w2+emOLyRwsk3CA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.27.3.tgz",
+            "integrity": "sha512-VGoVMcqcGkkoduzEqQ70ZK5OOHBDn5iYeHJSgkvNoSHzYHl0CaKoWxoDKJjSWC5DAM4mBU+tXTlsiUp3evRMfA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-bold": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.26.0.tgz",
-            "integrity": "sha512-j6CzTMofcGJ5iMoUgDRQpM0FkG00jBID3aKqs+UBbgtzLgtG/CI/91tMFv0XPC30LeFA895qYgvGZtHdejZhiQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.27.3.tgz",
+            "integrity": "sha512-pchbycFppBqBmvk+OxrQLIPZLNd3rNbcm7zOa+OTjluphpAcsJ6AmHBmiRhJUYWitV6/SA+0nujcaWxBp5hNcQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-bubble-menu": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.26.0.tgz",
-            "integrity": "sha512-H2E3Hp0lV79jQV8YGtdDJkXkUalXZeYzKCx+vCZlDpb2ChS7/rNT9YY7poRA1NlJLUO0DH1wbAnFhx9KZMUx5g==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.27.3.tgz",
+            "integrity": "sha512-PKSM9g8BXzO0Lxm2gOin7FAFvxO6T0QvlXTXVke/GJn/sR1tEz7w5ybsvweytUPmSliUc601pfIUOHKEhIVC2Q==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -5503,80 +5503,80 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-bullet-list": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.26.0.tgz",
-            "integrity": "sha512-Jv7BX+kBB2wUIvO/NhuUjv+T3kAed2Tjr664fgQ2zKT6X69jKIkYuCCedrIHuOyaOQ+SBDuH9h51wYv/E97QgQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.27.3.tgz",
+            "integrity": "sha512-owQW6mcgnYgQU1z5BqmslcjZFBUm1SGM/Ax++4R6XelIt/7ol6uSTjzjAzum+ASW7UlBbuJHuSgRjl8cA+RGkg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.26.0"
+                "@tiptap/extension-list": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-code": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.26.0.tgz",
-            "integrity": "sha512-VJYcV6rvjnENRTroOi9tDcHWW6G0pmCoRETwatlbgfDzuCmkTOwVwQjeJCXOVMMLNPzNiXZzibsRCUt+Azq/jw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.27.3.tgz",
+            "integrity": "sha512-T7JF10Y3k7fyVujXXLVubdUh7fctgBUoiuxbvjotpltg1U/mPbOcT0UW/uif9j3H8TFvAwNApVw3x8bwwFUakA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-code-block": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.26.0.tgz",
-            "integrity": "sha512-WPN9iZ3UjeDD2ckDzSs9tleibXv0cLj7j575NxuvjhwZTehYGNeYDSUTi+6DQUG6bKbhGg9Wcei5H0131vvJHg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.3.tgz",
+            "integrity": "sha512-3CVnzkpGoqqI5KaXI9l9PMwLkx34SYY63tpeo0I0QjDk4LU+JTAQDTPJFSwB4zTsHZ7ZFMU0jjasFOZ1kZRVgw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-document": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.26.0.tgz",
-            "integrity": "sha512-Xhd6DCjaxCN4otQNvV6qra+XuoIjk6Vyjm87E5xn5Y/BMw7UGAG7LTkk3C2IEvxKrVZwJjalfxEqdHOgXQzVfw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.27.3.tgz",
+            "integrity": "sha512-PR25MRv56Nm4ETVLwA8nAh/0RrVdvD4D2nxnAC8kUkxz1WOYDaqTfPqqEeSWDoUUTUp1I1xzDkD4x0gEnAlmZA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-dropcursor": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.26.0.tgz",
-            "integrity": "sha512-rhAtp5J/YVDUCUIc5T7b0XY9dLeuI72JgOr53w0QQc0VA0uwbfTn7sx0LI9PDCE9uwmDH8H3snVRZRnAvlM8oA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.27.3.tgz",
+            "integrity": "sha512-XsL0Ziual+ynXyx5JgLb0KIOShlMN3MW7+GQvf9PGRb1vOB7IOTRFDxMPrxDWcFIZ6WWMWSrbkCLOKHStt1BWg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "3.26.0"
+                "@tiptap/extensions": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-floating-menu": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.26.0.tgz",
-            "integrity": "sha512-reQ77NRYAOP7iPudsNbzLBuBTdL2aGxZzjccUFmE2lNdmwP23n9A/JhkuUhshVBs/6IozvahI+smG3Bnea0TCQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.27.3.tgz",
+            "integrity": "sha512-qL+g1Z6MqZvYG4mHTPwub9II2fWZY+2I5VFfV8fzqy1HchBOyY6Df0mRKDNb0bmjBdFabIXnswz3iqLx3mDTbw==",
             "license": "MIT",
             "optional": true,
             "funding": {
@@ -5585,80 +5585,80 @@
             },
             "peerDependencies": {
                 "@floating-ui/dom": "^1.0.0",
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-gapcursor": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.26.0.tgz",
-            "integrity": "sha512-SIe68SDwx2fozt/XKG0FhCwzz/yRN6Bvo4D5TqvfDg6NK3PQb1DS4GN9PilmJqbY+kXryuiWEEJOWi7HpO8SuQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.27.3.tgz",
+            "integrity": "sha512-MVBqzwYrDOttkn2GOrvvKTDCymfSS2VGSKpahcKKhge5mweSDiqko2X1vBDnMF8aVW3WxIFfDMmO4VMmh8HDZA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "3.26.0"
+                "@tiptap/extensions": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-hard-break": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.26.0.tgz",
-            "integrity": "sha512-baXvv/rtOTVd2Axjb7Zbb41Y9Qmy3U2fP7EHqLuhViqGxVX8LwQtP0PHUXEZkPokbBpRez10+dmOlvvsYFKAZQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.27.3.tgz",
+            "integrity": "sha512-cySObJITR2CRrWII87mI2LJ12wEETTnxt2p1vvC6ZtUmKnB50fOu+ux8ZEt6KYNocIOtrEZthNFzTOx7R7UtrQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-heading": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.26.0.tgz",
-            "integrity": "sha512-qenEQEgzE5FjQay/H6iKOnwIt6DPO27cS+v0mGhXmrL1MjrNER4X0ZkATJbVd0WA6ffsAGaP44NKYDworGeidw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.27.3.tgz",
+            "integrity": "sha512-QHXnsNic6iId8pnsFZ8z4PkX5L+HCHa/D7rAi3nNWtPlSIAOxo4nKrALcB5/tHmY+XL8kEXKH3nsNLNEDLCYPg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-horizontal-rule": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.26.0.tgz",
-            "integrity": "sha512-a+N/C4wkQV+/8x4ShdoiC2JdTW3Tw84C5cAloYLFMeaWmRa2me9ACSI+zo0SO9bbH9RJwsoRp7eaxBbk27eF1Q==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.27.3.tgz",
+            "integrity": "sha512-sNCuo0+Q001B5XTVWY+ULpWXQqtBNRmAqXxAexZl44bx3rDqHG8OzjwT4EM0LIj2+BYVbdqwaJ1vfQbZVEEbig==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-italic": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.26.0.tgz",
-            "integrity": "sha512-s8oFpH+0xmhvY19f452/2dExO3p1tjxh761g6cg4irwEUNUEAJKF2VLcjiaeOhNJ+pmnQYxb+VSkwkXvO+7vHQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.27.3.tgz",
+            "integrity": "sha512-7VpVi2vn8kGFAc/HLrt96J/E6+LXOGKn8xLhJS863t150yLIG3EPQLA1h+G5O6eo+/w+9YokvJAAJoeDihj1Jg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-link": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.26.0.tgz",
-            "integrity": "sha512-FA/d157aBxyvZFvsdc5eSu46tmHWXebAsqOQSvivOMyw+deBb00VlMsf+iD2J8+sekjbMYwx/hvbsu+xUoX43Q==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.27.3.tgz",
+            "integrity": "sha512-iXmu1tJ/3vP60c9d+zfO3+X64vod2EyBrM1qeufecAtWA6t0bT9tYeka0Zq6qDRGsZK5zViO9F2lsY7eHXiYuA==",
             "license": "MIT",
             "dependencies": {
                 "linkifyjs": "^4.3.3"
@@ -5668,176 +5668,176 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-list": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.26.0.tgz",
-            "integrity": "sha512-EM8woyHDNKLEQ+lWUEoDtA4KrwP6fei/mYX1NxseMzKHHo7LFecx7wk6sovAXZrUvdML/yFBihgiMiO5VIsfkg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.3.tgz",
+            "integrity": "sha512-52rcaSzYjtVGUrNkdB8k1Bw/rId2lBirrWMvmnBLsieoeFd8zo8ow5zkwV057BYSgWXfnMAV7GOpDyq2IoSD9A==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-list-item": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.26.0.tgz",
-            "integrity": "sha512-MccGyj9HY4fkl04eIiFoTCkr8067Jku/VVdJNtRWW104Spx43C/7V2zpbxPvpcDhq3dW384fDxYXfpnb186xLg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.27.3.tgz",
+            "integrity": "sha512-UddhVaQ7+V9IfQVVE8AJLNzSmyaaNpZPQsoPQxFNlJyOFxD6RwSTT8L4rb/TwbUctxSFWpyd1J7exzf33Ony/g==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.26.0"
+                "@tiptap/extension-list": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-list-keymap": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.26.0.tgz",
-            "integrity": "sha512-oBcj6qaNrRHQ+N0+pDuOVAQa4Nx9r8Cm5ANvyM2lTpoy60sOLOizuVvcvw1andVxbSrsZ1N/Sk+RZWyv1uoWyQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.27.3.tgz",
+            "integrity": "sha512-GZPVg4QCFm41yTMPEPeTlH2odNeQwRuWHY/pt3pI5LsfipQ4kDBv6h9we928vJQUnU2Gg9Y3cL5iRbmXIWWTUA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.26.0"
+                "@tiptap/extension-list": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-ordered-list": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.26.0.tgz",
-            "integrity": "sha512-ItLdFlcMsJz2vhbs1PcUfcN7nzVqGBOwPeCrrWxjrgscp+K3JoOGD+HhVVpBACOMwivUrlh8Ry5Ohvues2nOeA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.27.3.tgz",
+            "integrity": "sha512-oHYoE65WfRSM5tCcXi8MtQmzPxz83E2qw0pa2yHBKwr9xCCQUu8vJHJE+EJGduWdaNImv43+6/6kVMeYYbXRKg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.26.0"
+                "@tiptap/extension-list": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-paragraph": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.26.0.tgz",
-            "integrity": "sha512-h8fYLikg4qN39IghQ1y9g+zzUsgxBpDi5YS3IZbWoxWYYx1YqLL8nAvOiPr7Us14aQ0TjA2/xY7zqmyf29rX1A==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.27.3.tgz",
+            "integrity": "sha512-G5XPCN7lm0nULYPelJC2eUbKbt1q97j67e/HSWxwMYEXhceec5eNAtVfpDCRyXNO9osyBi2kXqLv/IQtxbch9A==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-strike": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.26.0.tgz",
-            "integrity": "sha512-jUll3Pqhq7u1JKvO0B6USW/bmVmUsO6sRcxo/d5tXqLhS0tWAobOGoGU2IgwXnQDSjf+vF73RYD5tRGDLkRC9Q==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.27.3.tgz",
+            "integrity": "sha512-dp6Rs3I4zLVJPvAw2Q9yrNuYKcX5LTONH3/oyULvGsrqq5DKz7pqscfwhwnDSzrgm/3aCz6B9r1BVHlYI/DXlA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-subscript": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.26.0.tgz",
-            "integrity": "sha512-6H4otLGtA2t2w/k4YxtUaDve+OV1ARUwJY2CDvOJrUWIUMCexCe6ppqR2ZAxkyGMa5TLHqgS0+7Z2wjrjERVPw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.27.3.tgz",
+            "integrity": "sha512-jsnoOWQ40kd7B6NMkdZxsZpcSk/+BevN6TprOVaPbo6cbThjmMCfyL/yCBRTWF/N2KMLMplz1WBhPUEG2Qk3mg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-superscript": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.26.0.tgz",
-            "integrity": "sha512-pewb9auEW6ZXZFZK4SacaLDj/qah8Ob4eVKUwW7dLjC6ga9UQmlhMnI/YhgB68qfbKxq7g4oYpHYj1zmU/74EQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.27.3.tgz",
+            "integrity": "sha512-y37F/ckFXvCkGVx0hk1qYr0XBXUuBstbwcy1AbW7xzPh07cn8xeTa21j3ytSMaAuSaaKh/TGIj/+DhbnovK8cw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-text": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.26.0.tgz",
-            "integrity": "sha512-yZXdevp3/8omGbb40Z52VfvID+tsRNhPQ1GNUToD56XSr2BjdJyAzAb9rWGgDKgVMUPLgJ26yT0O278RFqOKhA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.27.3.tgz",
+            "integrity": "sha512-wSatZ/bop0pleeC18nF90zvWWEoRe/ewZncvm8LjcMrXwq41kTEs3j7nZflMYAh7X8fZvu00UIMeEyCNJl+5Yg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-underline": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.26.0.tgz",
-            "integrity": "sha512-LlVkivH5cBwov/EMD8BL7ZRcU6YcadiSVIffLW1hyalw9YfhaFzoLxjtWhL7jiU/n2Kg+9dXSZxmV2hTeTwyrQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.27.3.tgz",
+            "integrity": "sha512-YH7ka/Rp7ZwlzTuQCcs0OZ4CMSx/P/MzbseQKxKebEIZreWaKMZAaED97Fnu0dA66VlreD4/1C7xHJy84ovamg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extensions": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.26.0.tgz",
-            "integrity": "sha512-4wajuqnO2X0+LVvsBjW/xk3/tmdb16bNL939QhicAay4YYqXITeV2v3XJsryzmG4L5GkK1yLxvRGk4aLoxWrnA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.3.tgz",
+            "integrity": "sha512-IA2QKUVJgzUPEhhkUfr6P5u5GFVfhiApiEaaHXBz07saL2c4HNoVs2RC18QlZDCtLNKrPR1mUScr72u7uYs+YQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/pm": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.26.0.tgz",
-            "integrity": "sha512-q4RDeWwVrhOL0jJCGRgGxLSdjOYwzQ4h2InURZVhC66433ipcHd6f3bqSOhcXZ4r0sFmMNsuF7aZmUntjWLc7w==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.3.tgz",
+            "integrity": "sha512-ppiG57RxM3HSHHgcHT0hP6Ib4P56Sd5itxdV4w0hIGHKPGyLLKiAkYp+htIHa9T7IvjMdaqxIlsfyV3ZKsS1sw==",
             "license": "MIT",
             "dependencies": {
-                "prosemirror-changeset": "^2.3.0",
-                "prosemirror-commands": "^1.6.2",
-                "prosemirror-dropcursor": "^1.8.1",
-                "prosemirror-gapcursor": "^1.3.2",
-                "prosemirror-history": "^1.4.1",
-                "prosemirror-inputrules": "^1.4.0",
+                "prosemirror-changeset": "^2.4.1",
+                "prosemirror-commands": "^1.7.1",
+                "prosemirror-dropcursor": "^1.8.2",
+                "prosemirror-gapcursor": "^1.4.1",
+                "prosemirror-history": "^1.5.0",
+                "prosemirror-inputrules": "^1.5.1",
                 "prosemirror-keymap": "^1.2.3",
-                "prosemirror-model": "^1.25.7",
-                "prosemirror-schema-list": "^1.5.0",
+                "prosemirror-model": "^1.25.9",
+                "prosemirror-schema-list": "^1.5.1",
                 "prosemirror-state": "^1.4.4",
-                "prosemirror-tables": "^1.8.0",
+                "prosemirror-tables": "^1.8.5",
                 "prosemirror-transform": "^1.12.0",
-                "prosemirror-view": "^1.41.8"
+                "prosemirror-view": "^1.41.9"
             },
             "funding": {
                 "type": "github",
@@ -5845,9 +5845,9 @@
             }
         },
         "node_modules/@tiptap/react": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.26.0.tgz",
-            "integrity": "sha512-NLPAG6tk4/AsfOsUNsbGqdgIHuGsD4A/hlYriozuo+LCAAduuluhzsL/MEHZXtFT4GXUOlCdaEqNCOrMuz/zaw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.27.3.tgz",
+            "integrity": "sha512-lanXxMScw/LevbRFuFw5MoQJ1grmHUDszwph2VIk4l2U5e/EDIw3rr4CeDME6Z4isVReD6zccMFVShkHqsv+jg==",
             "license": "MIT",
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
@@ -5859,12 +5859,12 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "optionalDependencies": {
-                "@tiptap/extension-bubble-menu": "^3.26.0",
-                "@tiptap/extension-floating-menu": "^3.26.0"
+                "@tiptap/extension-bubble-menu": "^3.27.3",
+                "@tiptap/extension-floating-menu": "^3.27.3"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0",
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3",
                 "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -5872,35 +5872,35 @@
             }
         },
         "node_modules/@tiptap/starter-kit": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.26.0.tgz",
-            "integrity": "sha512-o34EtMfqtBaljdmeElZsRG/067oGx9Zcq+j2GWo71KlZe22ga/ALexeTf1c+ETsjCxSTKR6eyQ4RZvz/2JpYfg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.27.3.tgz",
+            "integrity": "sha512-xX3baFqiC30skntdhxUUvyJo755ON9c1pE83+2Wiq2g+Qnffg9knUuLCZStHoZZ318yB0aBsKAMvHWLtYDo8AA==",
             "license": "MIT",
             "dependencies": {
-                "@tiptap/core": "^3.26.0",
-                "@tiptap/extension-blockquote": "^3.26.0",
-                "@tiptap/extension-bold": "^3.26.0",
-                "@tiptap/extension-bullet-list": "^3.26.0",
-                "@tiptap/extension-code": "^3.26.0",
-                "@tiptap/extension-code-block": "^3.26.0",
-                "@tiptap/extension-document": "^3.26.0",
-                "@tiptap/extension-dropcursor": "^3.26.0",
-                "@tiptap/extension-gapcursor": "^3.26.0",
-                "@tiptap/extension-hard-break": "^3.26.0",
-                "@tiptap/extension-heading": "^3.26.0",
-                "@tiptap/extension-horizontal-rule": "^3.26.0",
-                "@tiptap/extension-italic": "^3.26.0",
-                "@tiptap/extension-link": "^3.26.0",
-                "@tiptap/extension-list": "^3.26.0",
-                "@tiptap/extension-list-item": "^3.26.0",
-                "@tiptap/extension-list-keymap": "^3.26.0",
-                "@tiptap/extension-ordered-list": "^3.26.0",
-                "@tiptap/extension-paragraph": "^3.26.0",
-                "@tiptap/extension-strike": "^3.26.0",
-                "@tiptap/extension-text": "^3.26.0",
-                "@tiptap/extension-underline": "^3.26.0",
-                "@tiptap/extensions": "^3.26.0",
-                "@tiptap/pm": "^3.26.0"
+                "@tiptap/core": "^3.27.3",
+                "@tiptap/extension-blockquote": "^3.27.3",
+                "@tiptap/extension-bold": "^3.27.3",
+                "@tiptap/extension-bullet-list": "^3.27.3",
+                "@tiptap/extension-code": "^3.27.3",
+                "@tiptap/extension-code-block": "^3.27.3",
+                "@tiptap/extension-document": "^3.27.3",
+                "@tiptap/extension-dropcursor": "^3.27.3",
+                "@tiptap/extension-gapcursor": "^3.27.3",
+                "@tiptap/extension-hard-break": "^3.27.3",
+                "@tiptap/extension-heading": "^3.27.3",
+                "@tiptap/extension-horizontal-rule": "^3.27.3",
+                "@tiptap/extension-italic": "^3.27.3",
+                "@tiptap/extension-link": "^3.27.3",
+                "@tiptap/extension-list": "^3.27.3",
+                "@tiptap/extension-list-item": "^3.27.3",
+                "@tiptap/extension-list-keymap": "^3.27.3",
+                "@tiptap/extension-ordered-list": "^3.27.3",
+                "@tiptap/extension-paragraph": "^3.27.3",
+                "@tiptap/extension-strike": "^3.27.3",
+                "@tiptap/extension-text": "^3.27.3",
+                "@tiptap/extension-underline": "^3.27.3",
+                "@tiptap/extensions": "^3.27.3",
+                "@tiptap/pm": "^3.27.3"
             },
             "funding": {
                 "type": "github",
@@ -6116,17 +6116,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-            "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+            "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/type-utils": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/type-utils": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -6139,7 +6139,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.60.1",
+                "@typescript-eslint/parser": "^8.63.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -6155,16 +6155,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-            "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+            "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -6180,14 +6180,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-            "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+            "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.60.1",
-                "@typescript-eslint/types": "^8.60.1",
+                "@typescript-eslint/tsconfig-utils": "^8.63.0",
+                "@typescript-eslint/types": "^8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -6202,14 +6202,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-            "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+            "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1"
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6220,9 +6220,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-            "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+            "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6237,15 +6237,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-            "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+            "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -6262,9 +6262,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-            "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+            "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6276,16 +6276,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-            "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+            "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.60.1",
-                "@typescript-eslint/tsconfig-utils": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/project-service": "8.63.0",
+                "@typescript-eslint/tsconfig-utils": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -6314,9 +6314,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6343,9 +6343,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -6356,16 +6356,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-            "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+            "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1"
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6380,13 +6380,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-            "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+            "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/types": "8.63.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -9950,9 +9950,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/fast-equals": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-            "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.1.tgz",
+            "integrity": "sha512-DjlFSM5Pk9cGcL0q5QXl66eGzx0N6szNgaswwc5ZphlBohjTVJSnGgI+rJVOgOi65qUoQnDZN4nDqi33udtydQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -12394,9 +12394,9 @@
             }
         },
         "node_modules/libphonenumber-js": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.5.tgz",
-            "integrity": "sha512-7/kRezHmQlMfO6pmvt34orO/g3j1C47k8FCBXFgj/mklTLwQdBca1LkhDK6RM8UyM6JqHFAIikMdkKkyfQy39A==",
+            "version": "1.13.8",
+            "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.8.tgz",
+            "integrity": "sha512-80xal1m93rADejw2pMp2MSzFhHCPLEspjHxnH2UtqI+DgAmElsbmLMiqk9niwH9NWAfjsRtaJI+qBrOEmRx9nQ==",
             "license": "MIT"
         },
         "node_modules/lie": {
@@ -14174,9 +14174,9 @@
             }
         },
         "node_modules/prosemirror-dropcursor": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
-            "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+            "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-state": "^1.0.0",
@@ -14229,9 +14229,9 @@
             }
         },
         "node_modules/prosemirror-model": {
-            "version": "1.25.7",
-            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
-            "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
+            "version": "1.25.10",
+            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.10.tgz",
+            "integrity": "sha512-9n6rH4DbJU1eH4SxLt6Y0HhJIo6cZsb7DJ/30uob1hOKPeO6TAaMWI2tc7kwR92BjfPOU2fFHWbZLovLi3XQfA==",
             "license": "MIT",
             "dependencies": {
                 "orderedmap": "^2.0.0"
@@ -14282,12 +14282,12 @@
             }
         },
         "node_modules/prosemirror-view": {
-            "version": "1.41.8",
-            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
-            "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+            "version": "1.42.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.0.tgz",
+            "integrity": "sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==",
             "license": "MIT",
             "dependencies": {
-                "prosemirror-model": "^1.20.0",
+                "prosemirror-model": "^1.25.8",
                 "prosemirror-state": "^1.0.0",
                 "prosemirror-transform": "^1.1.0"
             }
@@ -14548,9 +14548,9 @@
             }
         },
         "node_modules/react-image-crop": {
-            "version": "11.0.10",
-            "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.10.tgz",
-            "integrity": "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==",
+            "version": "11.1.2",
+            "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.1.2.tgz",
+            "integrity": "sha512-+0Pc2fxpwKL4u4oLmdKBw8XSwUceFbXbKEHvFOlsl/MGB1OVNic4uBlAPmEHGXYgoJIq+b63xHbc/aJMG0AVkA==",
             "license": "ISC",
             "peerDependencies": {
                 "react": ">=16.13.1"
@@ -14588,9 +14588,9 @@
             "license": "MIT"
         },
         "node_modules/react-list": {
-            "version": "0.8.18",
-            "resolved": "https://registry.npmjs.org/react-list/-/react-list-0.8.18.tgz",
-            "integrity": "sha512-1OSdDvzuKuwDJvQNuhXxxL+jTmmdtKg1i6KtYgxI9XR98kbOql1FcSGP+Lcvo91fk3cYng+Z6YkC6X9HRJwxfw==",
+            "version": "0.8.19",
+            "resolved": "https://registry.npmjs.org/react-list/-/react-list-0.8.19.tgz",
+            "integrity": "sha512-8ORJHcMLbNsIn2YpB6v69FrF1gpM1bbfRKOMsDcKpiDRkmNsk9LDVptYqewmDRo0K7W2WPcveQftEes6ovD+Zw==",
             "license": "MIT",
             "peerDependencies": {
                 "react": "0.14 || 15 - 19"
@@ -16370,16 +16370,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-            "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+            "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.60.1",
-                "@typescript-eslint/parser": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1"
+                "@typescript-eslint/eslint-plugin": "8.63.0",
+                "@typescript-eslint/parser": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/admin/package.json
+++ b/admin/package.json
@@ -40,9 +40,9 @@
     },
     "dependencies": {
         "@apollo/client": "^3.14.1",
-        "@comet/admin": "9.0.0-beta.5",
-        "@comet/admin-icons": "9.0.0-beta.5",
-        "@comet/cms-admin": "9.0.0-beta.5",
+        "@comet/admin": "9.1.0",
+        "@comet/admin-icons": "9.1.0",
+        "@comet/cms-admin": "9.1.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@fontsource-variable/roboto-flex": "^5.2.8",
@@ -68,9 +68,9 @@
         "react-router-dom": "^5.3.4"
     },
     "devDependencies": {
-        "@comet/admin-generator": "9.0.0-beta.5",
-        "@comet/cli": "9.0.0-beta.5",
-        "@comet/eslint-config": "9.0.0-beta.5",
+        "@comet/admin-generator": "9.1.0",
+        "@comet/cli": "9.1.0",
+        "@comet/eslint-config": "9.1.0",
         "@formatjs/cli": "^6.16.11",
         "@graphql-codegen/add": "^7.0.1",
         "@graphql-codegen/cli": "^7.1.3",

--- a/api/block-meta.json
+++ b/api/block-meta.json
@@ -1049,6 +1049,11 @@
                 "name": "openInNewWindow",
                 "kind": "Boolean",
                 "nullable": false
+            },
+            {
+                "name": "noFollow",
+                "kind": "Boolean",
+                "nullable": false
             }
         ],
         "inputFields": [
@@ -1059,6 +1064,11 @@
             },
             {
                 "name": "openInNewWindow",
+                "kind": "Boolean",
+                "nullable": false
+            },
+            {
+                "name": "noFollow",
                 "kind": "Boolean",
                 "nullable": false
             }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@apollo/server": "^5.5.1",
                 "@as-integrations/express5": "^1.1.2",
-                "@comet/cms-api": "9.0.0-beta.5",
+                "@comet/cms-api": "9.1.0",
                 "@faker-js/faker": "10.5.0",
                 "@mikro-orm/cli": "^6.6.15",
                 "@mikro-orm/core": "^6.6.15",
@@ -44,9 +44,9 @@
                 "uuid": "^14.0.1"
             },
             "devDependencies": {
-                "@comet/api-generator": "9.0.0-beta.5",
-                "@comet/cli": "9.0.0-beta.5",
-                "@comet/eslint-config": "9.0.0-beta.5",
+                "@comet/api-generator": "9.1.0",
+                "@comet/cli": "9.1.0",
+                "@comet/eslint-config": "9.1.0",
                 "@nestjs/cli": "^11.0.23",
                 "@nestjs/schematics": "^11.1.0",
                 "@nestjs/testing": "^11.1.27",
@@ -70,6 +70,12 @@
             "engines": {
                 "node": "24"
             }
+        },
+        "node_modules/@acemir/cssom": {
+            "version": "0.9.31",
+            "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+            "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+            "license": "MIT"
         },
         "node_modules/@altano/repository-tools": {
             "version": "2.0.3",
@@ -578,107 +584,60 @@
                 "express": "^5.0.0"
             }
         },
-        "node_modules/@aws-crypto/crc32": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-            "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-            "license": "Apache-2.0",
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "license": "MIT",
             "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
-        "node_modules/@aws-crypto/crc32c": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
-            "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
-            "license": "Apache-2.0",
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+            "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+            "license": "MIT",
             "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.1.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.6"
             }
         },
-        "node_modules/@aws-crypto/sha1-browser": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
-            "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/supports-web-crypto": "^5.2.0",
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-browser": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-js": "^5.2.0",
-                "@aws-crypto/supports-web-crypto": "^5.2.0",
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-js": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/util": "^5.2.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^2.6.2"
-            },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "license": "MIT",
             "engines": {
-                "node": ">=16.0.0"
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
-        "node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-crypto/util": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "^3.222.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.6.2"
-            }
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "license": "MIT"
         },
         "node_modules/@aws-sdk/checksums": {
-            "version": "3.1000.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.1.tgz",
-            "integrity": "sha512-DFCtlisEuWzw7rESV65jHK7De1QsJZRZgUNJ8ovpmdVaayPrxvmlsAlW8hka9E7f9B31d1T7lHG9oozZf6Bp6w==",
+            "version": "3.1000.16",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
+            "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/crc32": "5.2.0",
-                "@aws-crypto/crc32c": "5.2.0",
-                "@aws-crypto/util": "5.2.0",
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -686,24 +645,21 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.1062.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1062.0.tgz",
-            "integrity": "sha512-fb+qr6Jql36rJwlOEgkzaC85PGZ1sQ1pTd5YlpwPbOoN54gpVBaSLsDp8GXMToymJzpDHd8GeSDalUak1W9gLw==",
+            "version": "3.1083.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1083.0.tgz",
+            "integrity": "sha512-3YOicHy6qjexsy4rHk5jPvtLgg6Ho1u+ycOWtJcVTAIMlMq32MRtnhllAyFSezhAXeBnnLLtKtAGXim7vV8oog==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha1-browser": "5.2.0",
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/credential-provider-node": "^3.972.51",
-                "@aws-sdk/middleware-flexible-checksums": "^3.974.26",
-                "@aws-sdk/middleware-sdk-s3": "^3.972.47",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.31",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/fetch-http-handler": "^5.4.6",
-                "@smithy/node-http-handler": "^4.7.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/checksums": "^3.1000.16",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/credential-provider-node": "^3.972.66",
+                "@aws-sdk/middleware-sdk-s3": "^3.972.62",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/fetch-http-handler": "^5.6.4",
+                "@smithy/node-http-handler": "^4.9.4",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -711,17 +667,17 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.974.17",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.17.tgz",
-            "integrity": "sha512-r8o4h2K7j6P9ngno+8ei0aK0U/4JwDb7A2fMMxGVoSqDN8AFlIzSDeZHME9LcVLR2codyhtr1WAAg+/nmkeeMA==",
+            "version": "3.975.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.1.tgz",
+            "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.10",
-                "@aws-sdk/xml-builder": "^3.972.27",
-                "@aws/lambda-invoke-store": "^0.2.2",
-                "@smithy/core": "^3.24.6",
-                "@smithy/signature-v4": "^5.4.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/types": "^3.974.0",
+                "@aws-sdk/xml-builder": "^3.972.34",
+                "@aws/lambda-invoke-store": "^0.3.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/signature-v4": "^5.6.3",
+                "@smithy/types": "^4.16.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             },
@@ -730,15 +686,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.972.43",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.43.tgz",
-            "integrity": "sha512-g0XVQKzaA/4cq1vz1IvCQwYM+1Pkv01J9yHDpCTXekVuGZRDEz0wqBQ1AuYTq7FM6uik4uBGH8Tb5d9YvgeA7g==",
+            "version": "3.972.57",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+            "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -746,17 +702,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.972.45",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.45.tgz",
-            "integrity": "sha512-w9PuOoKCt6+xoESvY+zlV0u3PKQ0mVL259PcsVR6a3S/uYJJHnIi4r1NxdJHEcNldUVRIciltWnFMGBR4YEm3g==",
+            "version": "3.972.59",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+            "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/fetch-http-handler": "^5.4.6",
-                "@smithy/node-http-handler": "^4.7.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/fetch-http-handler": "^5.6.4",
+                "@smithy/node-http-handler": "^4.9.4",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -764,23 +720,23 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.972.49",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.49.tgz",
-            "integrity": "sha512-83r5MK+PERv9irzky1o5aNbXiLuaLfeB7N8MrktB9USpoebdNtuG0Ek9ieIxpGH1aZ9a0nIaDaLjEr3EmOV3Ng==",
+            "version": "3.973.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+            "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/credential-provider-env": "^3.972.43",
-                "@aws-sdk/credential-provider-http": "^3.972.45",
-                "@aws-sdk/credential-provider-login": "^3.972.48",
-                "@aws-sdk/credential-provider-process": "^3.972.43",
-                "@aws-sdk/credential-provider-sso": "^3.972.48",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.48",
-                "@aws-sdk/nested-clients": "^3.997.16",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/credential-provider-imds": "^4.3.7",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/credential-provider-env": "^3.972.57",
+                "@aws-sdk/credential-provider-http": "^3.972.59",
+                "@aws-sdk/credential-provider-login": "^3.972.63",
+                "@aws-sdk/credential-provider-process": "^3.972.57",
+                "@aws-sdk/credential-provider-sso": "^3.973.1",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+                "@aws-sdk/nested-clients": "^3.997.31",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/credential-provider-imds": "^4.4.7",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -788,16 +744,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.972.48",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.48.tgz",
-            "integrity": "sha512-amPGeF6fcvLInK4Pu2k2Y2jHFR6MpaIKrZrbaf0QUnV3tjzjWh442eifZ2+KcmzFdsqyvyjBqAhq2JNLt1C5gA==",
+            "version": "3.972.63",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+            "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/nested-clients": "^3.997.16",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/nested-clients": "^3.997.31",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -805,21 +761,21 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.972.51",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.51.tgz",
-            "integrity": "sha512-mbhSY3ytXIGMuBoJsWCivk+63dtVlenT6wstUra07Lar4Ln2MVL8/j5zCTIOog+ig5/FlFJ8gcFU4nQZV+Jh4Q==",
+            "version": "3.972.66",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+            "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "^3.972.43",
-                "@aws-sdk/credential-provider-http": "^3.972.45",
-                "@aws-sdk/credential-provider-ini": "^3.972.49",
-                "@aws-sdk/credential-provider-process": "^3.972.43",
-                "@aws-sdk/credential-provider-sso": "^3.972.48",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.48",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/credential-provider-imds": "^4.3.7",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/credential-provider-env": "^3.972.57",
+                "@aws-sdk/credential-provider-http": "^3.972.59",
+                "@aws-sdk/credential-provider-ini": "^3.973.1",
+                "@aws-sdk/credential-provider-process": "^3.972.57",
+                "@aws-sdk/credential-provider-sso": "^3.973.1",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/credential-provider-imds": "^4.4.7",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -827,15 +783,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.972.43",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.43.tgz",
-            "integrity": "sha512-GPokLNyvTfCmuaHk+v3GKVs4ZT3cMu5kgS2a+NPkOMt96cq6fSIK0g+mZHpGS6Cd4QGrPKesANEaLUKgOskTzg==",
+            "version": "3.972.57",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+            "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -843,17 +799,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.972.48",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.48.tgz",
-            "integrity": "sha512-tf0sD47SeTgCDfOWYssctzGgwAuk8/ECjb7bom4wZ7P1om0qE8i2yjniUdvysmANm5haARr35O8vZnTe/UEtpQ==",
+            "version": "3.973.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+            "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/nested-clients": "^3.997.16",
-                "@aws-sdk/token-providers": "3.1062.0",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/nested-clients": "^3.997.31",
+                "@aws-sdk/token-providers": "3.1083.0",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -861,16 +817,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.972.48",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.48.tgz",
-            "integrity": "sha512-YYsumc2oe09gl4l+fjfmR64JDn6+0o4Ql5HMBkMuhFazO1tZlE5NjSnZM3oXHwenPjh2qow0TFgSIVjfWfsojg==",
+            "version": "3.972.63",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+            "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/nested-clients": "^3.997.16",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/nested-clients": "^3.997.31",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -878,13 +834,13 @@
             }
         },
         "node_modules/@aws-sdk/lib-storage": {
-            "version": "3.1062.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1062.0.tgz",
-            "integrity": "sha512-yD4P7+19rd4JqLmQ+Z4zcnPiwVQlsbT2Bppam5R8mOLpBHnWExVVRdlQy90RitQfevTGWj5CM/6EzWaGvs1h/w==",
+            "version": "3.1083.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1083.0.tgz",
+            "integrity": "sha512-r9PY+w81yeFIMKy/tAPRDD1AJnygXMdwUZOx5dGGHwx9Azk8CYYm9mA9Km5XxSdPihlrJ5sSleaHNFN0VHrIDA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "buffer": "5.6.0",
                 "events": "3.3.0",
                 "stream-browserify": "3.0.0",
@@ -894,33 +850,20 @@
                 "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "@aws-sdk/client-s3": "^3.1062.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.974.26",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.26.tgz",
-            "integrity": "sha512-WndRXQV8wAU/bW3GH8THumEOSV7FpS0AtoluT2M7lYaaDUyG0gOCD+DppB+IWQ4TPmzuTtFcCedh9xCzM4Zv4g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/checksums": "^3.1000.1",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
+                "@aws-sdk/client-s3": "^3.1083.0"
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.972.47",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.47.tgz",
-            "integrity": "sha512-fzVBvGib8P1G6RFV3qVTPlXy9bMFAy5nxhdhA7LwyhWjRkJufNfJIPiloZq2mt36YAXSlLsEa4s3Kgcw6cv3+g==",
+            "version": "3.972.62",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
+            "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.31",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -928,20 +871,18 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.997.16",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.16.tgz",
-            "integrity": "sha512-bGvfDgC2KQePjEmZdltScPPLKFoyjPElAXeZcLfvZ58J1AO283//WGtvp9GdnryLHTi7gis0UoCezqh0vl/nig==",
+            "version": "3.997.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+            "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.31",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/fetch-http-handler": "^5.4.6",
-                "@smithy/node-http-handler": "^4.7.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/fetch-http-handler": "^5.6.4",
+                "@smithy/node-http-handler": "^4.9.4",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -949,14 +890,14 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.996.31",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.31.tgz",
-            "integrity": "sha512-Kn2up9SlG1KC6wRtwf0d7waTGF6rvp9DxYqB54x6UCKdQ6kyaXCqHL4WGb5vUJga5kS8FxnjhY0LqM28aMvnNQ==",
+            "version": "3.996.39",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+            "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/signature-v4": "^5.4.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/signature-v4": "^5.6.3",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -964,16 +905,16 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.1062.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1062.0.tgz",
-            "integrity": "sha512-fvHh53zSm2FoQPgkw9thH5D7sd13bC0nPyuZb+mQJ85l5v7lQnsZ97u6e6YkJJN/LU1Mxm1/DLGrIIRR2L7tZw==",
+            "version": "3.1083.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+            "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.974.17",
-                "@aws-sdk/nested-clients": "^3.997.16",
-                "@aws-sdk/types": "^3.973.10",
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@aws-sdk/core": "^3.975.1",
+                "@aws-sdk/nested-clients": "^3.997.31",
+                "@aws-sdk/types": "^3.974.0",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -981,24 +922,12 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.973.10",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
-            "integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
+            "version": "3.974.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
+            "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.14.3",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.965.5",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-            "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1006,44 +935,22 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.27",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.27.tgz",
-            "integrity": "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g==",
+            "version": "3.972.34",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+            "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.14.3",
-                "fast-xml-parser": "5.7.3",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=20.0.0"
             }
         },
-        "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
-            "version": "5.7.3",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-            "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@nodable/entities": "^2.1.0",
-                "fast-xml-builder": "^1.1.7",
-                "path-expression-matcher": "^1.5.0",
-                "strnum": "^2.2.3"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
-            }
-        },
         "node_modules/@aws/lambda-invoke-store": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-            "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+            "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.0.0"
@@ -1066,14 +973,14 @@
             }
         },
         "node_modules/@azure-rest/core-client": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.6.1.tgz",
-            "integrity": "sha512-KzI10qnkWTsVS2yRBUdc8NLUJ1rOm+292mYs7Pe9wqAj/jv4bRskVm1l8XkKeVTN0OCQtrU5RG0Yhjbz1Wmg7g==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-2.7.0.tgz",
+            "integrity": "sha512-rL0lJqh1E8HLXNgjIw8cRyGAV/v+m6p1xRu/8OhsnmN8XHhwkyYJkAoGM+zrew96v7jZYPmVfy7pv7v4Iccfsg==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.1.2",
                 "@azure/core-auth": "^1.10.0",
-                "@azure/core-rest-pipeline": "^1.22.0",
+                "@azure/core-rest-pipeline": "^1.24.0",
                 "@azure/core-tracing": "^1.3.0",
                 "@typespec/ts-http-runtime": "^0.3.0",
                 "tslib": "^2.6.2"
@@ -1170,9 +1077,9 @@
             }
         },
         "node_modules/@azure/core-rest-pipeline": {
-            "version": "1.23.0",
-            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
-            "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+            "version": "1.24.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+            "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.1.2",
@@ -1240,9 +1147,9 @@
             }
         },
         "node_modules/@azure/storage-blob": {
-            "version": "12.32.0",
-            "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.32.0.tgz",
-            "integrity": "sha512-80LzSNnFQye2LCCBFghAJS6jJQJ7N4bfgZ6qDMgVGRtugZ7TLDKQZ2hczMigmZH3jAcMRdma/IygsC5+0gT7Tw==",
+            "version": "12.33.0",
+            "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.33.0.tgz",
+            "integrity": "sha512-2SX8oP8PyblUcAFZSg39c8Ls+tFjavM6sBeV+qpw33mRzRhI/5hrFJmJ/x0H9xx5l6ECPvgSP8uPxqTeVbHNIA==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.1.2",
@@ -1256,24 +1163,24 @@
                 "@azure/core-util": "^1.11.0",
                 "@azure/core-xml": "^1.4.5",
                 "@azure/logger": "^1.1.4",
-                "@azure/storage-common": "^12.4.0",
+                "@azure/storage-common": "^12.4.1",
                 "events": "^3.0.0",
                 "tslib": "^2.8.1"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.0.0"
             }
         },
         "node_modules/@azure/storage-common": {
-            "version": "12.4.0",
-            "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.4.0.tgz",
-            "integrity": "sha512-kNhJKMxQb374KOVt63CZnGIpDcrKNzJeyANLJymxE9mCJSdRGzb+Iv9oSIiCj6tNMLypr530b9ObOiA/5OvwOg==",
+            "version": "12.4.1",
+            "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.4.1.tgz",
+            "integrity": "sha512-t14unw/WofGDUi7TKJrsyXyPsN+NLgRm7hMaq0llxNmTIzt7f257+6LE6FKIJPh88zLj6M7LPvzve0fEYg/L3A==",
             "license": "MIT",
             "dependencies": {
                 "@azure/abort-controller": "^2.1.2",
                 "@azure/core-auth": "^1.9.0",
                 "@azure/core-http-compat": "^2.2.0",
-                "@azure/core-rest-pipeline": "^1.19.1",
+                "@azure/core-rest-pipeline": "^1.24.0",
                 "@azure/core-tracing": "^1.2.0",
                 "@azure/core-util": "^1.11.0",
                 "@azure/logger": "^1.1.4",
@@ -1586,6 +1493,18 @@
                 "url": "https://github.com/sponsors/Borewit"
             }
         },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
         "node_modules/@calm/eslint-plugin-react-intl": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@calm/eslint-plugin-react-intl/-/eslint-plugin-react-intl-1.4.1.tgz",
@@ -1611,13 +1530,13 @@
             }
         },
         "node_modules/@comet/api-generator": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/api-generator/-/api-generator-9.0.0-beta.5.tgz",
-            "integrity": "sha512-itWG6xqbg8leX4+PnHOy5xcPZ9GECHVFpGtVdX4IJ1oR833aTwUF/RBGzPBhK2nkGyusC+cOUaY7vVtvxyvQIQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/api-generator/-/api-generator-9.1.0.tgz",
+            "integrity": "sha512-tuvQ3z3W3aB5L3rlnqtMPiBAt5XYH5qhfbmhFx6Z4LVtu4oxtBkIsf1pVMQPTHIt4DkBX6yKxnnLQmZUUO9A+A==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@comet/cms-api": "9.0.0-beta.5",
+                "@comet/cms-api": "9.1.0",
                 "chokidar": "^4.0.3",
                 "commander": "^9.5.0",
                 "pluralize": "^8.0.0",
@@ -1640,9 +1559,9 @@
             }
         },
         "node_modules/@comet/cli": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/cli/-/cli-9.0.0-beta.5.tgz",
-            "integrity": "sha512-pf+4R978IX5sGLCOKhZjtV+KomDryjFHdNjVjDOjiqlW2cxwBtTSxkYfGSPfvoeIYvFN42V3Bq/WEJjub1W5BQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/cli/-/cli-9.1.0.tgz",
+            "integrity": "sha512-70F1IdhcaLh9bktn8c3FU+luG0ANIS5ntAunQyukGds0QeqW3sIPHhXlceaqUojY05uKCEFoPq3iiWQhTqzlog==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -1659,13 +1578,13 @@
             }
         },
         "node_modules/@comet/cms-api": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/cms-api/-/cms-api-9.0.0-beta.5.tgz",
-            "integrity": "sha512-d+M965SeaQqcLP+c8KB128/NUR0cVNBkJ62TNQuduwHPCuMJHZv4GXlMGx6abW72SpzX1m0ICZImngHNf/RW6w==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/cms-api/-/cms-api-9.1.0.tgz",
+            "integrity": "sha512-S/V9J+SBf2u01wkVugrOS9SB/FtEdjififyT6We/L+6Q0HHzzcsUe+O83nfOwOLvdvCmxADyrDv1BsB4Zg5IwQ==",
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@aws-sdk/client-s3": "^3.1053.0",
-                "@aws-sdk/lib-storage": "^3.1053.0",
+                "@aws-sdk/client-s3": "^3.1079.0",
+                "@aws-sdk/lib-storage": "^3.1079.0",
                 "@azure-rest/ai-translation-text": "^1.0.1",
                 "@azure/storage-blob": "^12.31.0",
                 "@fast-csv/parse": "^5.0.7",
@@ -1683,15 +1602,16 @@
                 "base64url": "^3.0.1",
                 "cron-parser": "^3.5.0",
                 "dataloader": "^2.2.3",
-                "date-fns": "^4.2.1",
+                "date-fns": "^4.4.0",
+                "dompurify": "^3.2.6",
                 "exifr": "^7.1.3",
-                "fast-xml-parser": "^5.8.0",
                 "file-type": "^21.3.4",
                 "graphql-parse-resolve-info": "^4.14.1",
                 "graphql-scalars": "^1.25.0",
                 "hasha": "^5.2.2",
                 "html-to-text": "^9.0.5",
                 "jose": "^5.10.0",
+                "jsdom": "^28.1.0",
                 "jszip": "^3.10.1",
                 "jwks-rsa": "^3.2.2",
                 "lodash.isequal": "^4.5.0",
@@ -1751,18 +1671,18 @@
             }
         },
         "node_modules/@comet/eslint-config": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/eslint-config/-/eslint-config-9.0.0-beta.5.tgz",
-            "integrity": "sha512-KbVm8A1TKAmNkwxUpwZZKJETTm230MWlMEMkLrWNiaWZFyX0zIzZ4a51kM9LIj/WqkF2Zs0kE+zfApUezmFGeg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/eslint-config/-/eslint-config-9.1.0.tgz",
+            "integrity": "sha512-gQK2nm7W8FBhLG4bnJfQXf3ufMB6D+qRya9m/3Q0jT7VJB+kA8bPhnvacH0ocQqNxeq0K/lVmkGFPHfjiiYMdw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@calm/eslint-plugin-react-intl": "^1.4.1",
-                "@comet/eslint-plugin": "9.0.0-beta.5",
+                "@comet/eslint-plugin": "9.1.0",
                 "@eslint/eslintrc": "^3.3.5",
                 "@eslint/js": "^9.39.4",
                 "@graphql-eslint/eslint-plugin": "^4.4.0",
-                "@next/eslint-plugin-next": "^16.2.6",
+                "@next/eslint-plugin-next": "^16.2.10",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-formatjs": "^5.4.2",
                 "eslint-plugin-import": "^2.32.0",
@@ -1775,7 +1695,7 @@
                 "eslint-plugin-unused-imports": "^4.4.1",
                 "globals": "^15.15.0",
                 "npm-run-all2": "^8.0.4",
-                "typescript-eslint": "^8.59.3"
+                "typescript-eslint": "^8.62.1"
             },
             "engines": {
                 "node": ">=22.0.0"
@@ -1904,9 +1824,9 @@
             }
         },
         "node_modules/@comet/eslint-plugin": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/eslint-plugin/-/eslint-plugin-9.0.0-beta.5.tgz",
-            "integrity": "sha512-XYuj83Q/WHrRnkUULeUo50jV13DZ+Xa2n7c5leatOdhSMj/xRDx7LjjMP21t2OHf4N75o8Fy9uyd38umbdcQFg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/eslint-plugin/-/eslint-plugin-9.1.0.tgz",
+            "integrity": "sha512-pkB8M69ITwDJC541WB0Z6wSZxfm05PqhQkzbCSWRFvd3Rl/QbGjLlt/Vy/lg7gZf35ZomVgHUeW0O5Vzevn6yQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -1928,6 +1848,140 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+            "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.9",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+            "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.1.0",
+                "@csstools/css-calc": "^3.2.1"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+            "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@emnapi/core": {
@@ -2163,6 +2217,23 @@
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+            "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@faker-js/faker": {
@@ -4046,9 +4117,9 @@
             }
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "16.2.7",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.7.tgz",
-            "integrity": "sha512-VbS+QgMHqvIDMTIqD2xMBKK1otIpdAUKA8VLHFwR9h6OfU/mOm7w/69nQcvdmI8hCk99Wr2AsGLn/PJ/tMHw1w==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
+            "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4086,9 +4157,9 @@
             }
         },
         "node_modules/@nodable/entities": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-            "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
             "funding": [
                 {
                     "type": "github",
@@ -6820,13 +6891,12 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.24.6",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
-            "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+            "version": "3.29.2",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.2.tgz",
+            "integrity": "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-crypto/crc32": "5.2.0",
-                "@smithy/types": "^4.14.3",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6834,13 +6904,13 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.3.8",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
-            "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
+            "version": "4.4.7",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.7.tgz",
+            "integrity": "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6848,39 +6918,27 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.4.6",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
-            "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+            "version": "5.6.4",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.4.tgz",
+            "integrity": "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@smithy/is-array-buffer": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.7.7",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
-            "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
+            "version": "4.9.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.4.tgz",
+            "integrity": "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6888,13 +6946,13 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.4.6",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
-            "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.3.tgz",
+            "integrity": "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.24.6",
-                "@smithy/types": "^4.14.3",
+                "@smithy/core": "^3.29.2",
+                "@smithy/types": "^4.16.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6902,41 +6960,15 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.14.3",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
-            "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+            "version": "4.16.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.0.tgz",
+            "integrity": "sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/util-buffer-from": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/is-array-buffer": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/util-utf8": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
             }
         },
         "node_modules/@standard-schema/spec": {
@@ -6947,180 +6979,180 @@
             "license": "MIT"
         },
         "node_modules/@tiptap/core": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.26.0.tgz",
-            "integrity": "sha512-7jTed/RirIVsp+lLdLvGzGqF3EBGpnGHGYKOwz6t28V2BIJLAFdUhfEVdWie7xPxQNWK0TP+fPlsqZS0vxfHBg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.3.tgz",
+            "integrity": "sha512-TJj5929M96C1KlH796wS8MywfHDh49RhmakOyzyMMc9pFmRj9UXi1gj0TCXgsZtjEOG7B+m/DRvNOvnuvR9kmg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-blockquote": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.26.0.tgz",
-            "integrity": "sha512-57accpka9affjiJRjP2LMNCDJDTMjTvO23RJCxtP43sp9cTIZ7YZnyDfRxCINTRBNK0X4o4w2+emOLyRwsk3CA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.27.3.tgz",
+            "integrity": "sha512-VGoVMcqcGkkoduzEqQ70ZK5OOHBDn5iYeHJSgkvNoSHzYHl0CaKoWxoDKJjSWC5DAM4mBU+tXTlsiUp3evRMfA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-bold": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.26.0.tgz",
-            "integrity": "sha512-j6CzTMofcGJ5iMoUgDRQpM0FkG00jBID3aKqs+UBbgtzLgtG/CI/91tMFv0XPC30LeFA895qYgvGZtHdejZhiQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.27.3.tgz",
+            "integrity": "sha512-pchbycFppBqBmvk+OxrQLIPZLNd3rNbcm7zOa+OTjluphpAcsJ6AmHBmiRhJUYWitV6/SA+0nujcaWxBp5hNcQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-bullet-list": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.26.0.tgz",
-            "integrity": "sha512-Jv7BX+kBB2wUIvO/NhuUjv+T3kAed2Tjr664fgQ2zKT6X69jKIkYuCCedrIHuOyaOQ+SBDuH9h51wYv/E97QgQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.27.3.tgz",
+            "integrity": "sha512-owQW6mcgnYgQU1z5BqmslcjZFBUm1SGM/Ax++4R6XelIt/7ol6uSTjzjAzum+ASW7UlBbuJHuSgRjl8cA+RGkg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.26.0"
+                "@tiptap/extension-list": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-code": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.26.0.tgz",
-            "integrity": "sha512-VJYcV6rvjnENRTroOi9tDcHWW6G0pmCoRETwatlbgfDzuCmkTOwVwQjeJCXOVMMLNPzNiXZzibsRCUt+Azq/jw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.27.3.tgz",
+            "integrity": "sha512-T7JF10Y3k7fyVujXXLVubdUh7fctgBUoiuxbvjotpltg1U/mPbOcT0UW/uif9j3H8TFvAwNApVw3x8bwwFUakA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-code-block": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.26.0.tgz",
-            "integrity": "sha512-WPN9iZ3UjeDD2ckDzSs9tleibXv0cLj7j575NxuvjhwZTehYGNeYDSUTi+6DQUG6bKbhGg9Wcei5H0131vvJHg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.3.tgz",
+            "integrity": "sha512-3CVnzkpGoqqI5KaXI9l9PMwLkx34SYY63tpeo0I0QjDk4LU+JTAQDTPJFSwB4zTsHZ7ZFMU0jjasFOZ1kZRVgw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-document": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.26.0.tgz",
-            "integrity": "sha512-Xhd6DCjaxCN4otQNvV6qra+XuoIjk6Vyjm87E5xn5Y/BMw7UGAG7LTkk3C2IEvxKrVZwJjalfxEqdHOgXQzVfw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.27.3.tgz",
+            "integrity": "sha512-PR25MRv56Nm4ETVLwA8nAh/0RrVdvD4D2nxnAC8kUkxz1WOYDaqTfPqqEeSWDoUUTUp1I1xzDkD4x0gEnAlmZA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-dropcursor": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.26.0.tgz",
-            "integrity": "sha512-rhAtp5J/YVDUCUIc5T7b0XY9dLeuI72JgOr53w0QQc0VA0uwbfTn7sx0LI9PDCE9uwmDH8H3snVRZRnAvlM8oA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.27.3.tgz",
+            "integrity": "sha512-XsL0Ziual+ynXyx5JgLb0KIOShlMN3MW7+GQvf9PGRb1vOB7IOTRFDxMPrxDWcFIZ6WWMWSrbkCLOKHStt1BWg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "3.26.0"
+                "@tiptap/extensions": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-gapcursor": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.26.0.tgz",
-            "integrity": "sha512-SIe68SDwx2fozt/XKG0FhCwzz/yRN6Bvo4D5TqvfDg6NK3PQb1DS4GN9PilmJqbY+kXryuiWEEJOWi7HpO8SuQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.27.3.tgz",
+            "integrity": "sha512-MVBqzwYrDOttkn2GOrvvKTDCymfSS2VGSKpahcKKhge5mweSDiqko2X1vBDnMF8aVW3WxIFfDMmO4VMmh8HDZA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extensions": "3.26.0"
+                "@tiptap/extensions": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-hard-break": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.26.0.tgz",
-            "integrity": "sha512-baXvv/rtOTVd2Axjb7Zbb41Y9Qmy3U2fP7EHqLuhViqGxVX8LwQtP0PHUXEZkPokbBpRez10+dmOlvvsYFKAZQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.27.3.tgz",
+            "integrity": "sha512-cySObJITR2CRrWII87mI2LJ12wEETTnxt2p1vvC6ZtUmKnB50fOu+ux8ZEt6KYNocIOtrEZthNFzTOx7R7UtrQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-heading": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.26.0.tgz",
-            "integrity": "sha512-qenEQEgzE5FjQay/H6iKOnwIt6DPO27cS+v0mGhXmrL1MjrNER4X0ZkATJbVd0WA6ffsAGaP44NKYDworGeidw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.27.3.tgz",
+            "integrity": "sha512-QHXnsNic6iId8pnsFZ8z4PkX5L+HCHa/D7rAi3nNWtPlSIAOxo4nKrALcB5/tHmY+XL8kEXKH3nsNLNEDLCYPg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-horizontal-rule": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.26.0.tgz",
-            "integrity": "sha512-a+N/C4wkQV+/8x4ShdoiC2JdTW3Tw84C5cAloYLFMeaWmRa2me9ACSI+zo0SO9bbH9RJwsoRp7eaxBbk27eF1Q==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.27.3.tgz",
+            "integrity": "sha512-sNCuo0+Q001B5XTVWY+ULpWXQqtBNRmAqXxAexZl44bx3rDqHG8OzjwT4EM0LIj2+BYVbdqwaJ1vfQbZVEEbig==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-italic": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.26.0.tgz",
-            "integrity": "sha512-s8oFpH+0xmhvY19f452/2dExO3p1tjxh761g6cg4irwEUNUEAJKF2VLcjiaeOhNJ+pmnQYxb+VSkwkXvO+7vHQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.27.3.tgz",
+            "integrity": "sha512-7VpVi2vn8kGFAc/HLrt96J/E6+LXOGKn8xLhJS863t150yLIG3EPQLA1h+G5O6eo+/w+9YokvJAAJoeDihj1Jg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-link": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.26.0.tgz",
-            "integrity": "sha512-FA/d157aBxyvZFvsdc5eSu46tmHWXebAsqOQSvivOMyw+deBb00VlMsf+iD2J8+sekjbMYwx/hvbsu+xUoX43Q==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.27.3.tgz",
+            "integrity": "sha512-iXmu1tJ/3vP60c9d+zfO3+X64vod2EyBrM1qeufecAtWA6t0bT9tYeka0Zq6qDRGsZK5zViO9F2lsY7eHXiYuA==",
             "license": "MIT",
             "dependencies": {
                 "linkifyjs": "^4.3.3"
@@ -7130,176 +7162,176 @@
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-list": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.26.0.tgz",
-            "integrity": "sha512-EM8woyHDNKLEQ+lWUEoDtA4KrwP6fei/mYX1NxseMzKHHo7LFecx7wk6sovAXZrUvdML/yFBihgiMiO5VIsfkg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.3.tgz",
+            "integrity": "sha512-52rcaSzYjtVGUrNkdB8k1Bw/rId2lBirrWMvmnBLsieoeFd8zo8ow5zkwV057BYSgWXfnMAV7GOpDyq2IoSD9A==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-list-item": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.26.0.tgz",
-            "integrity": "sha512-MccGyj9HY4fkl04eIiFoTCkr8067Jku/VVdJNtRWW104Spx43C/7V2zpbxPvpcDhq3dW384fDxYXfpnb186xLg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.27.3.tgz",
+            "integrity": "sha512-UddhVaQ7+V9IfQVVE8AJLNzSmyaaNpZPQsoPQxFNlJyOFxD6RwSTT8L4rb/TwbUctxSFWpyd1J7exzf33Ony/g==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.26.0"
+                "@tiptap/extension-list": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-list-keymap": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.26.0.tgz",
-            "integrity": "sha512-oBcj6qaNrRHQ+N0+pDuOVAQa4Nx9r8Cm5ANvyM2lTpoy60sOLOizuVvcvw1andVxbSrsZ1N/Sk+RZWyv1uoWyQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.27.3.tgz",
+            "integrity": "sha512-GZPVg4QCFm41yTMPEPeTlH2odNeQwRuWHY/pt3pI5LsfipQ4kDBv6h9we928vJQUnU2Gg9Y3cL5iRbmXIWWTUA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.26.0"
+                "@tiptap/extension-list": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-ordered-list": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.26.0.tgz",
-            "integrity": "sha512-ItLdFlcMsJz2vhbs1PcUfcN7nzVqGBOwPeCrrWxjrgscp+K3JoOGD+HhVVpBACOMwivUrlh8Ry5Ohvues2nOeA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.27.3.tgz",
+            "integrity": "sha512-oHYoE65WfRSM5tCcXi8MtQmzPxz83E2qw0pa2yHBKwr9xCCQUu8vJHJE+EJGduWdaNImv43+6/6kVMeYYbXRKg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/extension-list": "3.26.0"
+                "@tiptap/extension-list": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-paragraph": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.26.0.tgz",
-            "integrity": "sha512-h8fYLikg4qN39IghQ1y9g+zzUsgxBpDi5YS3IZbWoxWYYx1YqLL8nAvOiPr7Us14aQ0TjA2/xY7zqmyf29rX1A==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.27.3.tgz",
+            "integrity": "sha512-G5XPCN7lm0nULYPelJC2eUbKbt1q97j67e/HSWxwMYEXhceec5eNAtVfpDCRyXNO9osyBi2kXqLv/IQtxbch9A==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-strike": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.26.0.tgz",
-            "integrity": "sha512-jUll3Pqhq7u1JKvO0B6USW/bmVmUsO6sRcxo/d5tXqLhS0tWAobOGoGU2IgwXnQDSjf+vF73RYD5tRGDLkRC9Q==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.27.3.tgz",
+            "integrity": "sha512-dp6Rs3I4zLVJPvAw2Q9yrNuYKcX5LTONH3/oyULvGsrqq5DKz7pqscfwhwnDSzrgm/3aCz6B9r1BVHlYI/DXlA==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-subscript": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.26.0.tgz",
-            "integrity": "sha512-6H4otLGtA2t2w/k4YxtUaDve+OV1ARUwJY2CDvOJrUWIUMCexCe6ppqR2ZAxkyGMa5TLHqgS0+7Z2wjrjERVPw==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.27.3.tgz",
+            "integrity": "sha512-jsnoOWQ40kd7B6NMkdZxsZpcSk/+BevN6TprOVaPbo6cbThjmMCfyL/yCBRTWF/N2KMLMplz1WBhPUEG2Qk3mg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-superscript": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.26.0.tgz",
-            "integrity": "sha512-pewb9auEW6ZXZFZK4SacaLDj/qah8Ob4eVKUwW7dLjC6ga9UQmlhMnI/YhgB68qfbKxq7g4oYpHYj1zmU/74EQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.27.3.tgz",
+            "integrity": "sha512-y37F/ckFXvCkGVx0hk1qYr0XBXUuBstbwcy1AbW7xzPh07cn8xeTa21j3ytSMaAuSaaKh/TGIj/+DhbnovK8cw==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-text": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.26.0.tgz",
-            "integrity": "sha512-yZXdevp3/8omGbb40Z52VfvID+tsRNhPQ1GNUToD56XSr2BjdJyAzAb9rWGgDKgVMUPLgJ26yT0O278RFqOKhA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.27.3.tgz",
+            "integrity": "sha512-wSatZ/bop0pleeC18nF90zvWWEoRe/ewZncvm8LjcMrXwq41kTEs3j7nZflMYAh7X8fZvu00UIMeEyCNJl+5Yg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extension-underline": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.26.0.tgz",
-            "integrity": "sha512-LlVkivH5cBwov/EMD8BL7ZRcU6YcadiSVIffLW1hyalw9YfhaFzoLxjtWhL7jiU/n2Kg+9dXSZxmV2hTeTwyrQ==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.27.3.tgz",
+            "integrity": "sha512-YH7ka/Rp7ZwlzTuQCcs0OZ4CMSx/P/MzbseQKxKebEIZreWaKMZAaED97Fnu0dA66VlreD4/1C7xHJy84ovamg==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0"
+                "@tiptap/core": "3.27.3"
             }
         },
         "node_modules/@tiptap/extensions": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.26.0.tgz",
-            "integrity": "sha512-4wajuqnO2X0+LVvsBjW/xk3/tmdb16bNL939QhicAay4YYqXITeV2v3XJsryzmG4L5GkK1yLxvRGk4aLoxWrnA==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.3.tgz",
+            "integrity": "sha512-IA2QKUVJgzUPEhhkUfr6P5u5GFVfhiApiEaaHXBz07saL2c4HNoVs2RC18QlZDCtLNKrPR1mUScr72u7uYs+YQ==",
             "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
             },
             "peerDependencies": {
-                "@tiptap/core": "3.26.0",
-                "@tiptap/pm": "3.26.0"
+                "@tiptap/core": "3.27.3",
+                "@tiptap/pm": "3.27.3"
             }
         },
         "node_modules/@tiptap/pm": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.26.0.tgz",
-            "integrity": "sha512-q4RDeWwVrhOL0jJCGRgGxLSdjOYwzQ4h2InURZVhC66433ipcHd6f3bqSOhcXZ4r0sFmMNsuF7aZmUntjWLc7w==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.3.tgz",
+            "integrity": "sha512-ppiG57RxM3HSHHgcHT0hP6Ib4P56Sd5itxdV4w0hIGHKPGyLLKiAkYp+htIHa9T7IvjMdaqxIlsfyV3ZKsS1sw==",
             "license": "MIT",
             "dependencies": {
-                "prosemirror-changeset": "^2.3.0",
-                "prosemirror-commands": "^1.6.2",
-                "prosemirror-dropcursor": "^1.8.1",
-                "prosemirror-gapcursor": "^1.3.2",
-                "prosemirror-history": "^1.4.1",
-                "prosemirror-inputrules": "^1.4.0",
+                "prosemirror-changeset": "^2.4.1",
+                "prosemirror-commands": "^1.7.1",
+                "prosemirror-dropcursor": "^1.8.2",
+                "prosemirror-gapcursor": "^1.4.1",
+                "prosemirror-history": "^1.5.0",
+                "prosemirror-inputrules": "^1.5.1",
                 "prosemirror-keymap": "^1.2.3",
-                "prosemirror-model": "^1.25.7",
-                "prosemirror-schema-list": "^1.5.0",
+                "prosemirror-model": "^1.25.9",
+                "prosemirror-schema-list": "^1.5.1",
                 "prosemirror-state": "^1.4.4",
-                "prosemirror-tables": "^1.8.0",
+                "prosemirror-tables": "^1.8.5",
                 "prosemirror-transform": "^1.12.0",
-                "prosemirror-view": "^1.41.8"
+                "prosemirror-view": "^1.41.9"
             },
             "funding": {
                 "type": "github",
@@ -7307,35 +7339,35 @@
             }
         },
         "node_modules/@tiptap/starter-kit": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.26.0.tgz",
-            "integrity": "sha512-o34EtMfqtBaljdmeElZsRG/067oGx9Zcq+j2GWo71KlZe22ga/ALexeTf1c+ETsjCxSTKR6eyQ4RZvz/2JpYfg==",
+            "version": "3.27.3",
+            "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.27.3.tgz",
+            "integrity": "sha512-xX3baFqiC30skntdhxUUvyJo755ON9c1pE83+2Wiq2g+Qnffg9knUuLCZStHoZZ318yB0aBsKAMvHWLtYDo8AA==",
             "license": "MIT",
             "dependencies": {
-                "@tiptap/core": "^3.26.0",
-                "@tiptap/extension-blockquote": "^3.26.0",
-                "@tiptap/extension-bold": "^3.26.0",
-                "@tiptap/extension-bullet-list": "^3.26.0",
-                "@tiptap/extension-code": "^3.26.0",
-                "@tiptap/extension-code-block": "^3.26.0",
-                "@tiptap/extension-document": "^3.26.0",
-                "@tiptap/extension-dropcursor": "^3.26.0",
-                "@tiptap/extension-gapcursor": "^3.26.0",
-                "@tiptap/extension-hard-break": "^3.26.0",
-                "@tiptap/extension-heading": "^3.26.0",
-                "@tiptap/extension-horizontal-rule": "^3.26.0",
-                "@tiptap/extension-italic": "^3.26.0",
-                "@tiptap/extension-link": "^3.26.0",
-                "@tiptap/extension-list": "^3.26.0",
-                "@tiptap/extension-list-item": "^3.26.0",
-                "@tiptap/extension-list-keymap": "^3.26.0",
-                "@tiptap/extension-ordered-list": "^3.26.0",
-                "@tiptap/extension-paragraph": "^3.26.0",
-                "@tiptap/extension-strike": "^3.26.0",
-                "@tiptap/extension-text": "^3.26.0",
-                "@tiptap/extension-underline": "^3.26.0",
-                "@tiptap/extensions": "^3.26.0",
-                "@tiptap/pm": "^3.26.0"
+                "@tiptap/core": "^3.27.3",
+                "@tiptap/extension-blockquote": "^3.27.3",
+                "@tiptap/extension-bold": "^3.27.3",
+                "@tiptap/extension-bullet-list": "^3.27.3",
+                "@tiptap/extension-code": "^3.27.3",
+                "@tiptap/extension-code-block": "^3.27.3",
+                "@tiptap/extension-document": "^3.27.3",
+                "@tiptap/extension-dropcursor": "^3.27.3",
+                "@tiptap/extension-gapcursor": "^3.27.3",
+                "@tiptap/extension-hard-break": "^3.27.3",
+                "@tiptap/extension-heading": "^3.27.3",
+                "@tiptap/extension-horizontal-rule": "^3.27.3",
+                "@tiptap/extension-italic": "^3.27.3",
+                "@tiptap/extension-link": "^3.27.3",
+                "@tiptap/extension-list": "^3.27.3",
+                "@tiptap/extension-list-item": "^3.27.3",
+                "@tiptap/extension-list-keymap": "^3.27.3",
+                "@tiptap/extension-ordered-list": "^3.27.3",
+                "@tiptap/extension-paragraph": "^3.27.3",
+                "@tiptap/extension-strike": "^3.27.3",
+                "@tiptap/extension-text": "^3.27.3",
+                "@tiptap/extension-underline": "^3.27.3",
+                "@tiptap/extensions": "^3.27.3",
+                "@tiptap/pm": "^3.27.3"
             },
             "funding": {
                 "type": "github",
@@ -7783,6 +7815,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/@types/validator": {
             "version": "13.15.10",
             "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
@@ -7800,17 +7839,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-            "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+            "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/type-utils": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/type-utils": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -7823,7 +7862,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.60.1",
+                "@typescript-eslint/parser": "^8.63.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -7839,16 +7878,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-            "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+            "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -7864,14 +7903,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-            "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+            "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.60.1",
-                "@typescript-eslint/types": "^8.60.1",
+                "@typescript-eslint/tsconfig-utils": "^8.63.0",
+                "@typescript-eslint/types": "^8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -7886,14 +7925,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-            "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+            "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1"
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7904,9 +7943,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-            "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+            "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7921,15 +7960,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-            "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+            "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -7946,9 +7985,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-            "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+            "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7960,16 +7999,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-            "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+            "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.60.1",
-                "@typescript-eslint/tsconfig-utils": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/project-service": "8.63.0",
+                "@typescript-eslint/tsconfig-utils": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -7998,9 +8037,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8027,9 +8066,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -8040,16 +8079,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-            "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+            "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1"
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8064,13 +8103,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-            "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+            "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/types": "8.63.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -8680,6 +8719,18 @@
                 "node": ">=14"
             }
         },
+        "node_modules/anynum": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/append-field": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -8979,9 +9030,9 @@
             }
         },
         "node_modules/bare-fs": {
-            "version": "4.7.2",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-            "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+            "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -9003,33 +9054,21 @@
                 }
             }
         },
-        "node_modules/bare-os": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-            "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-            "license": "Apache-2.0",
-            "peer": true,
-            "engines": {
-                "bare": ">=1.14.0"
-            }
-        },
         "node_modules/bare-path": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-            "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+            "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
             "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "bare-os": "^3.0.1"
-            }
+            "peer": true
         },
         "node_modules/bare-stream": {
-            "version": "2.13.1",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
-            "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+            "version": "2.13.3",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+            "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
+                "b4a": "^1.8.1",
                 "streamx": "^2.25.0",
                 "teex": "^1.0.1"
             },
@@ -9100,6 +9139,15 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
             }
         },
         "node_modules/bignumber.js": {
@@ -9876,11 +9924,39 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/cssfilter": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
             "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
             "license": "MIT"
+        },
+        "node_modules/cssstyle": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+            "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.0.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+                "css-tree": "^3.1.0",
+                "lru-cache": "^11.2.6"
+            },
+            "engines": {
+                "node": ">=20"
+            }
         },
         "node_modules/data-uri-to-buffer": {
             "version": "4.0.1",
@@ -9889,6 +9965,28 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/data-view-buffer": {
@@ -9982,7 +10080,6 @@
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
             "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/deep-is": {
@@ -10186,6 +10283,15 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.4.11",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+            "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/domutils": {
@@ -11365,9 +11471,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
+            "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
             "funding": [
                 {
                     "type": "github",
@@ -11381,9 +11487,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
-            "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+            "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
             "funding": [
                 {
                     "type": "github",
@@ -11392,10 +11498,11 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@nodable/entities": "^2.1.0",
+                "@nodable/entities": "^2.2.0",
                 "fast-xml-builder": "^1.2.0",
+                "is-unsafe": "^1.0.1",
                 "path-expression-matcher": "^1.5.0",
-                "strnum": "^2.3.0",
+                "strnum": "^2.4.1",
                 "xml-naming": "^0.1.0"
             },
             "bin": {
@@ -11709,17 +11816,17 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -12599,6 +12706,18 @@
                 "node": ">=14"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/html-to-text": {
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
@@ -13186,6 +13305,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "license": "MIT"
+        },
         "node_modules/is-promise": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -13313,6 +13438,18 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/is-unsafe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+            "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
@@ -13539,6 +13676,55 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdom": {
+            "version": "28.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+            "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+            "license": "MIT",
+            "dependencies": {
+                "@acemir/cssom": "^0.9.31",
+                "@asamuzakjp/dom-selector": "^6.8.1",
+                "@bramus/specificity": "^2.4.2",
+                "@exodus/bytes": "^1.11.0",
+                "cssstyle": "^6.0.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^8.0.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.0",
+                "undici": "^7.21.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/jsep": {
@@ -14626,6 +14812,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "license": "CC0-1.0"
+        },
         "node_modules/media-typer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -15107,6 +15299,31 @@
                 }
             }
         },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause",
+            "peer": true
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/node-releases": {
             "version": "2.0.47",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
@@ -15118,9 +15335,9 @@
             }
         },
         "node_modules/nodemailer": {
-            "version": "8.0.10",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
-            "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
+            "version": "8.0.11",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.11.tgz",
+            "integrity": "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==",
             "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"
@@ -15437,15 +15654,27 @@
             }
         },
         "node_modules/openai": {
-            "version": "6.42.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
-            "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
+            "version": "6.45.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+            "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
             "license": "Apache-2.0",
             "peerDependencies": {
+                "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+                "@smithy/hash-node": ">=4.3.0 <5",
+                "@smithy/signature-v4": ">=5.4.0 <6",
                 "ws": "^8.18.0",
                 "zod": "^3.25 || ^4.0"
             },
             "peerDependenciesMeta": {
+                "@aws-sdk/credential-provider-node": {
+                    "optional": true
+                },
+                "@smithy/hash-node": {
+                    "optional": true
+                },
+                "@smithy/signature-v4": {
+                    "optional": true
+                },
                 "ws": {
                     "optional": true
                 },
@@ -15721,6 +15950,30 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/parseley": {
             "version": "0.12.1",
             "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
@@ -15761,9 +16014,9 @@
             }
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+            "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
             "funding": [
                 {
                     "type": "github",
@@ -16199,9 +16452,9 @@
             }
         },
         "node_modules/prosemirror-dropcursor": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
-            "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+            "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
             "license": "MIT",
             "dependencies": {
                 "prosemirror-state": "^1.0.0",
@@ -16254,9 +16507,9 @@
             }
         },
         "node_modules/prosemirror-model": {
-            "version": "1.25.7",
-            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
-            "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
+            "version": "1.25.10",
+            "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.10.tgz",
+            "integrity": "sha512-9n6rH4DbJU1eH4SxLt6Y0HhJIo6cZsb7DJ/30uob1hOKPeO6TAaMWI2tc7kwR92BjfPOU2fFHWbZLovLi3XQfA==",
             "license": "MIT",
             "dependencies": {
                 "orderedmap": "^2.0.0"
@@ -16307,12 +16560,12 @@
             }
         },
         "node_modules/prosemirror-view": {
-            "version": "1.41.8",
-            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
-            "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+            "version": "1.42.0",
+            "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.0.tgz",
+            "integrity": "sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==",
             "license": "MIT",
             "dependencies": {
-                "prosemirror-model": "^1.20.0",
+                "prosemirror-model": "^1.25.8",
                 "prosemirror-state": "^1.0.0",
                 "prosemirror-transform": "^1.1.0"
             }
@@ -16940,6 +17193,18 @@
                 "node": ">=11.0.0"
             }
         },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
         "node_modules/schema-utils": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -17359,7 +17624,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -17550,9 +17814,9 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.27.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
-            "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+            "version": "2.28.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+            "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -17767,16 +18031,19 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-            "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "anynum": "^1.0.1"
+            }
         },
         "node_modules/strtok3": {
             "version": "10.3.5",
@@ -17875,6 +18142,12 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "license": "MIT"
+        },
         "node_modules/sync-fetch": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.6.0.tgz",
@@ -17966,9 +18239,9 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-            "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+            "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -18264,6 +18537,24 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/tldts": {
+            "version": "7.4.7",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.7.tgz",
+            "integrity": "sha512-56L0/9HELHSsG1bFCzay8UoLxzRL7kpFf7Wl5q/kSYwiSJGACvro61xnKzPNM+SadxllzdtXsKDSXE7HPeqIAw==",
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.4.7"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.4.7",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.7.tgz",
+            "integrity": "sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==",
+            "license": "MIT"
+        },
         "node_modules/to-buffer": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -18317,12 +18608,29 @@
                 "url": "https://github.com/sponsors/Borewit"
             }
         },
+        "node_modules/tough-cookie": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+            "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
             "license": "MIT",
-            "peer": true
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
         },
         "node_modules/ts-api-utils": {
             "version": "2.5.0",
@@ -18600,16 +18908,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-            "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+            "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.60.1",
-                "@typescript-eslint/parser": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1"
+                "@typescript-eslint/eslint-plugin": "8.63.0",
+                "@typescript-eslint/parser": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -18702,6 +19010,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/undici": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -19085,6 +19402,18 @@
             "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
             "license": "MIT"
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/walk-up-path": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
@@ -19119,11 +19448,13 @@
             }
         },
         "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
             "license": "BSD-2-Clause",
-            "peer": true
+            "engines": {
+                "node": ">=20"
+            }
         },
         "node_modules/webpack": {
             "version": "5.106.2",
@@ -19302,14 +19633,17 @@
             }
         },
         "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/which": {
@@ -19501,6 +19835,15 @@
                 }
             }
         },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/xml-naming": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -19515,6 +19858,12 @@
             "engines": {
                 "node": ">=16.0.0"
             }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "license": "MIT"
         },
         "node_modules/xss": {
             "version": "1.0.15",

--- a/api/package.json
+++ b/api/package.json
@@ -43,7 +43,7 @@
     "dependencies": {
         "@apollo/server": "^5.5.1",
         "@as-integrations/express5": "^1.1.2",
-        "@comet/cms-api": "9.0.0-beta.5",
+        "@comet/cms-api": "9.1.0",
         "@faker-js/faker": "10.5.0",
         "@mikro-orm/cli": "^6.6.15",
         "@mikro-orm/core": "^6.6.15",
@@ -77,9 +77,9 @@
         "uuid": "^14.0.1"
     },
     "devDependencies": {
-        "@comet/api-generator": "9.0.0-beta.5",
-        "@comet/cli": "9.0.0-beta.5",
-        "@comet/eslint-config": "9.0.0-beta.5",
+        "@comet/api-generator": "9.1.0",
+        "@comet/cli": "9.1.0",
+        "@comet/eslint-config": "9.1.0",
         "@nestjs/cli": "^11.0.23",
         "@nestjs/schematics": "^11.1.0",
         "@nestjs/testing": "^11.1.27",

--- a/api/schema.gql
+++ b/api/schema.gql
@@ -7,6 +7,11 @@ input AttachedDocumentInput {
   type: String!
 }
 
+"""
+The `BigInt` scalar type represents non-fractional signed whole numeric values.
+"""
+scalar BigInt
+
 input BooleanFilter {
   equal: Boolean
 }
@@ -61,7 +66,7 @@ type DamFile {
   license: DamFileLicense
   mimetype: String!
   name: String!
-  size: Int!
+  size: BigInt!
   thisFileIsAlternativeFor: [DamMediaAlternative!]!
   title: String
   updatedAt: DateTime!
@@ -846,8 +851,10 @@ input WarningFilter {
   and: [WarningFilter!]
   createdAt: DateTimeFilter
   message: StringFilter
+  name: StringFilter
   or: [WarningFilter!]
   scope: ScopeFilter
+  secondaryInformation: StringFilter
   severity: WarningSeverityEnumFilter
   status: WarningStatusEnumFilter
   type: StringFilter
@@ -874,6 +881,7 @@ input WarningSort {
 enum WarningSortField {
   createdAt
   message
+  name
   severity
   status
   type

--- a/api/src/db/fixtures/generators/blocks/navigation/link-block-fixture.service.ts
+++ b/api/src/db/fixtures/generators/blocks/navigation/link-block-fixture.service.ts
@@ -15,6 +15,7 @@ export class LinkBlockFixtureService {
                     props: {
                         targetUrl: faker.helpers.arrayElement(urls),
                         openInNewWindow: faker.datatype.boolean(),
+                        noFollow: faker.datatype.boolean(),
                     },
                 },
             ],

--- a/create-app/eslint.config.mjs
+++ b/create-app/eslint.config.mjs
@@ -7,6 +7,7 @@ const config = defineConfig([
     {
         rules: {
             "@comet/no-other-module-relative-import": "off",
+            "package-json/require-exports": "off", // TODO reenable after migrating to ESM
         },
     },
 ]);

--- a/create-app/package-lock.json
+++ b/create-app/package-lock.json
@@ -20,7 +20,7 @@
                 "create-app": "bin/index.js"
             },
             "devDependencies": {
-                "@comet/eslint-config": "^8.25.0",
+                "@comet/eslint-config": "9.1.0",
                 "@tsconfig/node24": "^24.0.4",
                 "@types/node": "^24.13.2",
                 "knip": "^6.24.0",
@@ -39,6 +39,315 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-plugin-utils": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.7"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-import-assertions": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
+            "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@calm/eslint-plugin-react-intl": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@calm/eslint-plugin-react-intl/-/eslint-plugin-react-intl-1.4.1.tgz",
@@ -53,30 +362,31 @@
             }
         },
         "node_modules/@comet/eslint-config": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@comet/eslint-config/-/eslint-config-8.25.0.tgz",
-            "integrity": "sha512-yZvkFRlUXfvOVA2L2Dv2Yp88uYLGoLGQ+pjiz8MaoA9b6lpWeqY3kYRjgWU6B3vVt7SQ81JPBSny+5jJhnuAUQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/eslint-config/-/eslint-config-9.1.0.tgz",
+            "integrity": "sha512-gQK2nm7W8FBhLG4bnJfQXf3ufMB6D+qRya9m/3Q0jT7VJB+kA8bPhnvacH0ocQqNxeq0K/lVmkGFPHfjiiYMdw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@calm/eslint-plugin-react-intl": "^1.4.1",
-                "@comet/eslint-plugin": "8.25.0",
-                "@eslint/eslintrc": "^3.3.3",
-                "@eslint/js": "^9.39.2",
-                "@next/eslint-plugin-next": "^16.1.6",
+                "@comet/eslint-plugin": "9.1.0",
+                "@eslint/eslintrc": "^3.3.5",
+                "@eslint/js": "^9.39.4",
+                "@graphql-eslint/eslint-plugin": "^4.4.0",
+                "@next/eslint-plugin-next": "^16.2.10",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-formatjs": "^5.4.2",
                 "eslint-plugin-import": "^2.32.0",
                 "eslint-plugin-jsonc": "^2.21.1",
-                "eslint-plugin-package-json": "^0.88.2",
-                "eslint-plugin-prettier": "^5.5.5",
+                "eslint-plugin-package-json": "^0.91.2",
+                "eslint-plugin-prettier": "^5.5.6",
                 "eslint-plugin-react": "^7.37.5",
                 "eslint-plugin-react-hooks": "^5.2.0",
                 "eslint-plugin-simple-import-sort": "^12.1.1",
                 "eslint-plugin-unused-imports": "^4.4.1",
                 "globals": "^15.15.0",
                 "npm-run-all2": "^8.0.4",
-                "typescript-eslint": "^8.53.0"
+                "typescript-eslint": "^8.62.1"
             },
             "engines": {
                 "node": ">=22.0.0"
@@ -205,9 +515,9 @@
             }
         },
         "node_modules/@comet/eslint-plugin": {
-            "version": "8.25.0",
-            "resolved": "https://registry.npmjs.org/@comet/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
-            "integrity": "sha512-rt7TReq+h9kbaVzZHGMU4nW0iOEWuzSC7c1MhOXK1uiku1Y9pBmWqstlszSmBj0UjFDvNnroA7Deod4CREhCgw==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/eslint-plugin/-/eslint-plugin-9.1.0.tgz",
+            "integrity": "sha512-pkB8M69ITwDJC541WB0Z6wSZxfm05PqhQkzbCSWRFvd3Rl/QbGjLlt/Vy/lg7gZf35ZomVgHUeW0O5Vzevn6yQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -250,6 +560,50 @@
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@envelop/core": {
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/@envelop/core/-/core-5.5.1.tgz",
+            "integrity": "sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@envelop/instrumentation": "^1.0.0",
+                "@envelop/types": "^5.2.1",
+                "@whatwg-node/promise-helpers": "^1.2.4",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@envelop/instrumentation": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
+            "integrity": "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@whatwg-node/promise-helpers": "^1.2.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@envelop/types": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@envelop/types/-/types-5.2.1.tgz",
+            "integrity": "sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -398,6 +752,13 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@fastify/busboy": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+            "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@formatjs/ecma402-abstract": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
@@ -494,6 +855,758 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@graphql-eslint/eslint-plugin": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-4.4.0.tgz",
+            "integrity": "sha512-dhW6fpk3Souuaphhc38uMAGCcgKMgtCJWFygIKODw/Kns43wiQqRPVay0aNFY1JBx3aevn4KPT/BCOdm6HNncA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/code-file-loader": "^8.0.0",
+                "@graphql-tools/graphql-tag-pluck": "^8.3.4",
+                "@graphql-tools/utils": "^10.0.0",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.2.12",
+                "graphql-config": "^5.1.3",
+                "graphql-depth-limit": "^1.1.0",
+                "lodash.lowercase": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@apollo/subgraph": "^2",
+                "eslint": ">=8.44.0",
+                "graphql": "^16",
+                "json-schema-to-ts": "^3"
+            },
+            "peerDependenciesMeta": {
+                "@apollo/subgraph": {
+                    "optional": true
+                },
+                "json-schema-to-ts": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@graphql-hive/signal": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-hive/signal/-/signal-2.0.0.tgz",
+            "integrity": "sha512-Pz8wB3K0iU6ae9S1fWfsmJX24CcGeTo6hE7T44ucmV/ALKRj+bxClmqrYcDT7v3f0d12Rh4FAXBb6gon+WkDpQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/batch-execute": {
+            "version": "10.0.9",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-10.0.9.tgz",
+            "integrity": "sha512-khIgAPlyaWJ3dVX6SsqOkABZCH1Gii32WHn3xMzavupsxPCfb/9G3zjdswptzTFrOcZ92dWo7MXvwNFkRfNN4w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/utils": "^11.0.0",
+                "@whatwg-node/promise-helpers": "^1.3.2",
+                "dataloader": "^2.2.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/batch-execute/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/code-file-loader": {
+            "version": "8.1.34",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.34.tgz",
+            "integrity": "sha512-MOyXRh94EvBVIhlS8kh3aRhQiOdPfiCZvfd7g5/t7cW3VMa+Z0sfuNI5r7E2VxXZkZUsJ6yRj56EwAPY5fR4Jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/graphql-tag-pluck": "8.3.33",
+                "@graphql-tools/utils": "^11.2.0",
+                "globby": "^11.0.3",
+                "tslib": "^2.4.0",
+                "unixify": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/code-file-loader/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/delegate": {
+            "version": "12.0.18",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-12.0.18.tgz",
+            "integrity": "sha512-EUlzdJNNzYkxW2zUakUNGvDrKp6LHRKS3CkOzTV4DeQNwHHR73P/qgo1GPnh4O2HPfrggVfQ1INRxA5pdppT+Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/batch-execute": "^10.0.9",
+                "@graphql-tools/executor": "^1.4.13",
+                "@graphql-tools/schema": "^10.0.29",
+                "@graphql-tools/utils": "^11.0.0",
+                "@repeaterjs/repeater": "^3.0.6",
+                "@whatwg-node/promise-helpers": "^1.3.2",
+                "dataloader": "^2.2.3",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/delegate/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.5.5.tgz",
+            "integrity": "sha512-JAdn4G+ehthnGdJABS+wO6LxAIcoGPiSRHIz1ECYLtaQGkpFIdqH6BLUbZcToX/W/nmOG0kTFLoepCGkugbsBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/utils": "^11.2.0",
+                "@graphql-typed-document-node/core": "^3.2.0",
+                "@repeaterjs/repeater": "^3.0.4",
+                "@whatwg-node/disposablestack": "^0.0.6",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor-common": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-common/-/executor-common-1.0.6.tgz",
+            "integrity": "sha512-23/K5C+LSlHDI0mj2SwCJ33RcELCcyDUgABm1Z8St7u/4Z5+95i925H/NAjUyggRjiaY8vYtNiMOPE49aPX1sg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@envelop/core": "^5.4.0",
+                "@graphql-tools/utils": "^11.0.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor-common/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor-graphql-ws": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-3.1.5.tgz",
+            "integrity": "sha512-WXRsfwu9AkrORD9nShrd61OwwxeQ5+eXYcABRR3XPONFIS8pWQfDJGGqxql9/227o/s0DV5SIfkBURb5Knzv+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/executor-common": "^1.0.6",
+                "@graphql-tools/utils": "^11.0.0",
+                "@whatwg-node/disposablestack": "^0.0.6",
+                "graphql-ws": "^6.0.6",
+                "isows": "^1.0.7",
+                "tslib": "^2.8.1",
+                "ws": "^8.18.3"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor-graphql-ws/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor-http": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-3.3.0.tgz",
+            "integrity": "sha512-IkKXIjSg9U8MNsQUBVJAXE4+LSxaQ0cs7p5JTALLGDABY1o17vPDRwWALsX81AXD5dY27ihi/+OhGMueW/Fopg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-hive/signal": "^2.0.0",
+                "@graphql-tools/executor-common": "^1.0.6",
+                "@graphql-tools/utils": "^11.0.0",
+                "@repeaterjs/repeater": "^3.0.4",
+                "@whatwg-node/disposablestack": "^0.0.6",
+                "@whatwg-node/fetch": "^0.10.13",
+                "@whatwg-node/promise-helpers": "^1.3.2",
+                "meros": "^1.3.2",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor-http/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor-legacy-ws": {
+            "version": "1.1.30",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.1.30.tgz",
+            "integrity": "sha512-sCY1Fn5M7/1eMbFuvEwzGqAdjdkKECUWbaTO1lo3RQVyHC8HUYe/DB/tEoQfT7TQarauX9KjXsSf2uqCyJyOOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/utils": "^11.2.0",
+                "@types/ws": "^8.0.0",
+                "isomorphic-ws": "^5.0.0",
+                "tslib": "^2.4.0",
+                "ws": "^8.21.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor-legacy-ws/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/executor/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/graphql-file-loader": {
+            "version": "8.1.16",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.1.16.tgz",
+            "integrity": "sha512-1OFMnmadqwAalty2nka8EpejM1T9QCgtNApGMTvIsz141y9lfK3Xj9lNTgsJk+u2kyjsEYyo3F+tc6wEqMdqTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/import": "^7.1.16",
+                "@graphql-tools/utils": "^11.2.0",
+                "globby": "^11.0.3",
+                "tslib": "^2.4.0",
+                "unixify": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/graphql-file-loader/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/graphql-tag-pluck": {
+            "version": "8.3.33",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.33.tgz",
+            "integrity": "sha512-12nfDKx1wpe5Zd2VhUCuZKaNzd0/ZQf1X5M8jHkRloGA61k+vr7dTDdlWrWcGDr1EufuoviL+e1UqGxD8D9PWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.29.7",
+                "@babel/parser": "^7.29.3",
+                "@babel/plugin-syntax-import-assertions": "^7.26.0",
+                "@babel/traverse": "^7.26.10",
+                "@babel/types": "^7.26.10",
+                "@graphql-tools/utils": "^11.2.0",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/graphql-tag-pluck/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/import": {
+            "version": "7.1.16",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.1.16.tgz",
+            "integrity": "sha512-vx2v9qqiQF15RK3O68kaqSXDQ/++xU4qkcNBCME3Y82qLGsKNPNJT8alklWlAJAvFs7LrXrCr+ZqbidO4pYaxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/utils": "^11.2.0",
+                "resolve-from": "5.0.0",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/import/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/import/node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@graphql-tools/json-file-loader": {
+            "version": "8.0.30",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.30.tgz",
+            "integrity": "sha512-Ij97Ij+Uz3hvuetRTLX8v/d3ZyT2i17nyZN1maCTHW3tOypUevnuW7TKJcX0rOCsiP0juIcnnG91hcKsBh0Ktw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/utils": "^11.2.0",
+                "globby": "^11.0.3",
+                "tslib": "^2.4.0",
+                "unixify": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/json-file-loader/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/load": {
+            "version": "8.1.13",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.1.13.tgz",
+            "integrity": "sha512-XstLIkH2gDVk3xlzbfNyR+MFGTaCop2rJSEyShXTnIy4Sh+DoNM6re8eXzZPIOs+N33kuOWm6e0EGE9tGpHUNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/schema": "^10.0.36",
+                "@graphql-tools/utils": "^11.2.0",
+                "p-limit": "3.1.0",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/load/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/merge": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.2.0.tgz",
+            "integrity": "sha512-kChDH/sOxm3TCICup5NgTiz/aJBk+5GAuC0lfJS8FcRfsqZvlCkNwpsYTGAATBCJMrgZ9+csRugCjS97jPcNMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/utils": "^11.2.0",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/merge/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/schema": {
+            "version": "10.0.36",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.36.tgz",
+            "integrity": "sha512-g8S5aLirZInoi3NojzmBxwsZfVawOE0UBlVWYe8kDAR0FxS0riBDiyW7JnlAKayooHMRAMwGaze4RQU3VTTyig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/merge": "^9.2.0",
+                "@graphql-tools/utils": "^11.2.0",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/schema/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/url-loader": {
+            "version": "9.1.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-9.1.4.tgz",
+            "integrity": "sha512-w65oPIvUxdJ8eSydIfG2jllbBY5+lijG1mCY22kpGcp/gqPUdH+L6TIr81ZeTZIWnV2DioSP7g3rLE4JGW6uyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/executor-graphql-ws": "^3.1.4",
+                "@graphql-tools/executor-http": "^3.3.0",
+                "@graphql-tools/executor-legacy-ws": "^1.1.30",
+                "@graphql-tools/utils": "^11.2.0",
+                "@graphql-tools/wrap": "^11.1.1",
+                "@types/ws": "^8.0.0",
+                "@whatwg-node/fetch": "^0.10.13",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "isomorphic-ws": "^5.0.0",
+                "sync-fetch": "0.6.0",
+                "tslib": "^2.4.0",
+                "ws": "^8.21.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/url-loader/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/utils": {
+            "version": "10.11.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.11.0.tgz",
+            "integrity": "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/wrap": {
+            "version": "11.1.17",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-11.1.17.tgz",
+            "integrity": "sha512-eY5dh9ZewdzSbYNtrfhXvpaKvMyGNCGrH2VBMTs5hnyE9tncsmZjcaVRW+CGiUJUIp184D+FYrK7tmW/hUm0dQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/delegate": "^12.0.18",
+                "@graphql-tools/schema": "^10.0.29",
+                "@graphql-tools/utils": "^11.0.0",
+                "@whatwg-node/promise-helpers": "^1.3.2",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/wrap/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-typed-document-node/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.2",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -555,12 +1668,55 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.6",
@@ -582,13 +1738,43 @@
             }
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "16.2.7",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.7.tgz",
-            "integrity": "sha512-VbS+QgMHqvIDMTIqD2xMBKK1otIpdAUKA8VLHFwR9h6OfU/mOm7w/69nQcvdmI8hCk99Wr2AsGLn/PJ/tMHw1w==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
+            "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-glob": "3.3.1"
+            }
+        },
+        "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+            "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.2",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=8.6.0"
+            }
+        },
+        "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1336,6 +2522,13 @@
                 "url": "https://opencollective.com/pkgr"
             }
         },
+        "node_modules/@repeaterjs/repeater": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.1.0.tgz",
+            "integrity": "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@rtsao/scc": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1408,18 +2601,28 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-            "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+            "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/type-utils": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/type-utils": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -1432,7 +2635,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.60.1",
+                "@typescript-eslint/parser": "^8.63.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -1448,16 +2651,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-            "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+            "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1473,14 +2676,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-            "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+            "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.60.1",
-                "@typescript-eslint/types": "^8.60.1",
+                "@typescript-eslint/tsconfig-utils": "^8.63.0",
+                "@typescript-eslint/types": "^8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1495,14 +2698,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-            "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+            "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1"
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1513,9 +2716,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-            "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+            "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1530,15 +2733,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-            "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+            "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -1555,9 +2758,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-            "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+            "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1569,16 +2772,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-            "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+            "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.60.1",
-                "@typescript-eslint/tsconfig-utils": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/project-service": "8.63.0",
+                "@typescript-eslint/tsconfig-utils": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -1607,9 +2810,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1636,16 +2839,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-            "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+            "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1"
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1660,13 +2863,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-            "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+            "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/types": "8.63.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -1688,6 +2891,63 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@whatwg-node/disposablestack": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/disposablestack/-/disposablestack-0.0.6.tgz",
+            "integrity": "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "tslib": "^2.6.3"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/fetch": {
+            "version": "0.10.13",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.13.tgz",
+            "integrity": "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@whatwg-node/node-fetch": "^0.8.3",
+                "urlpattern-polyfill": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/node-fetch": {
+            "version": "0.8.6",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.8.6.tgz",
+            "integrity": "sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@fastify/busboy": "^3.1.1",
+                "@whatwg-node/disposablestack": "^0.0.6",
+                "@whatwg-node/promise-helpers": "^1.3.2",
+                "tslib": "^2.6.3"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/promise-helpers": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+            "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.3"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/acorn": {
@@ -1725,19 +2985,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/ansi-regex": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/ansi-styles": {
@@ -1799,6 +3046,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/array.prototype.findlast": {
@@ -1921,6 +3178,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/async-function": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -1953,6 +3220,19 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.42",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.15",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -1974,6 +3254,40 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.28.5",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+            "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.10.42",
+                "caniuse-lite": "^1.0.30001800",
+                "electron-to-chromium": "^1.5.387",
+                "node-releases": "^2.0.50",
+                "update-browserslist-db": "^1.2.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
         "node_modules/call-bind": {
@@ -2035,6 +3349,27 @@
                 "node": ">=6"
             }
         },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001803",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+            "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2057,21 +3392,6 @@
             "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/cliui": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^7.2.0",
-                "strip-ansi": "^7.1.0",
-                "wrap-ansi": "^9.0.0"
-            },
-            "engines": {
-                "node": ">=20"
-            }
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -2106,6 +3426,53 @@
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
         },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/cosmiconfig": {
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "import-fresh": "^3.3.0",
+                "js-yaml": "^4.1.0",
+                "parse-json": "^5.2.0",
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/cross-inspect": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+            "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2118,6 +3485,16 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/data-view-buffer": {
@@ -2173,6 +3550,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/dataloader": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+            "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -2276,6 +3660,19 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
+        "node_modules/dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-type": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/doctrine": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2304,12 +3701,12 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/emoji-regex": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.389",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+            "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
             "dev": true,
-            "license": "MIT"
+            "license": "ISC"
         },
         "node_modules/emoji-regex-xs": {
             "version": "2.0.1",
@@ -2319,6 +3716,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
             }
         },
         "node_modules/es-abstract": {
@@ -2612,9 +4019,9 @@
             }
         },
         "node_modules/eslint-fix-utils": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/eslint-fix-utils/-/eslint-fix-utils-0.4.2.tgz",
-            "integrity": "sha512-n7ZTcwwkP5scedlhvWMcqxED+O1NzXcj5Rxn/0kJQMP88k02vRcBfQ1qsk/JHb6Aw8bajFoetFCCBiNIcNCsvA==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-fix-utils/-/eslint-fix-utils-0.4.3.tgz",
+            "integrity": "sha512-EKzNhsNavV5DdkHVltHBM9TqfsonCmiUhOm1Ra97zo03M9IAx3wtM1eC27eWGMj/D3LrALmHHNe1QlQH1P7Nxw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2805,9 +4212,9 @@
             }
         },
         "node_modules/eslint-plugin-package-json": {
-            "version": "0.88.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-0.88.3.tgz",
-            "integrity": "sha512-tvWYMeWofMRMc5kQ/rg+ueB2/0EEUP1OI1J17LH5Fd46oYrVSde9kE1fPKGCTxCwYmCUrHOUj9i8ET9H/KEPBA==",
+            "version": "0.91.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-0.91.2.tgz",
+            "integrity": "sha512-tuPjHVYOjqEJtErmzuYiQY6o877l9Kb7+lfLhR/mAzHuy9CBqhRreIGPsQmVM/dMJ8yQVg92Bz1vBAgugELIXw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2815,8 +4222,8 @@
                 "change-case": "^5.4.4",
                 "detect-indent": "^7.0.2",
                 "detect-newline": "^4.0.1",
-                "eslint-fix-utils": "~0.4.0",
-                "package-json-validator": "~0.60.0",
+                "eslint-fix-utils": "~0.4.1",
+                "package-json-validator": "^1.4.1",
                 "semver": "^7.7.3",
                 "sort-object-keys": "^2.0.0",
                 "sort-package-json": "^3.4.0",
@@ -2827,7 +4234,7 @@
             },
             "peerDependencies": {
                 "eslint": ">=8.0.0",
-                "jsonc-eslint-parser": "^2.0.0"
+                "jsonc-eslint-parser": ">=2.0.0"
             }
         },
         "node_modules/eslint-plugin-prettier": {
@@ -3044,9 +4451,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/fast-glob": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-            "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3054,7 +4461,7 @@
                 "@nodelib/fs.walk": "^1.2.3",
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
+                "micromatch": "^4.0.8"
             },
             "engines": {
                 "node": ">=8.6.0"
@@ -3121,6 +4528,30 @@
                 "picomatch": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/fetch-blob": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
             }
         },
         "node_modules/file-entry-cache": {
@@ -3215,6 +4646,19 @@
                 "node": ">=18.3.0"
             }
         },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3266,27 +4710,14 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/get-caller-file": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/get-east-asian-width": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
-            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=6.9.0"
             }
         },
         "node_modules/get-intrinsic": {
@@ -3464,6 +4895,27 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/globby": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.9",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3483,6 +4935,150 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/graphql": {
+            "version": "16.14.2",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+            "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+            }
+        },
+        "node_modules/graphql-config": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.1.6.tgz",
+            "integrity": "sha512-fCkYnm4Kdq3un0YIM4BCZHVR5xl0UeLP6syxxO7KAstdY7QVyVvTHP0kRPDYEP1v08uwtJVgis5sj3IOTLOniQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-tools/graphql-file-loader": "^8.0.0",
+                "@graphql-tools/json-file-loader": "^8.0.0",
+                "@graphql-tools/load": "^8.1.0",
+                "@graphql-tools/merge": "^9.0.0",
+                "@graphql-tools/url-loader": "^9.0.0",
+                "@graphql-tools/utils": "^11.0.0",
+                "cosmiconfig": "^8.1.0",
+                "jiti": "^2.0.0",
+                "minimatch": "^10.0.0",
+                "string-env-interpolation": "^1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
+            },
+            "peerDependencies": {
+                "cosmiconfig-toml-loader": "^1.0.0",
+                "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            },
+            "peerDependenciesMeta": {
+                "cosmiconfig-toml-loader": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/graphql-config/node_modules/@graphql-tools/utils": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.2.0.tgz",
+            "integrity": "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "@whatwg-node/promise-helpers": "^1.0.0",
+                "cross-inspect": "1.0.1",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/graphql-config/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/graphql-config/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/graphql-config/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/graphql-depth-limit": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+            "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "arrify": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "*"
+            }
+        },
+        "node_modules/graphql-ws": {
+            "version": "6.0.8",
+            "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.8.tgz",
+            "integrity": "sha512-m3EOaNsUBXwAnkBWbzPfe0Nq8pXUfxsWnolC54sru3FzHvhTZL0Ouf/BoQsaGAXqM+YPerXOJ47BUnmgmoupCw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "@fastify/websocket": "^10 || ^11",
+                "crossws": "~0.3",
+                "graphql": "^15.10.1 || ^16",
+                "ws": "^8"
+            },
+            "peerDependenciesMeta": {
+                "@fastify/websocket": {
+                    "optional": true
+                },
+                "crossws": {
+                    "optional": true
+                },
+                "ws": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
@@ -3577,6 +5173,19 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/hosted-git-info": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3643,6 +5252,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-async-function": {
             "version": "2.1.1",
@@ -4042,6 +5658,32 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
+        "node_modules/isomorphic-ws": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+            "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ws": "*"
+            }
+        },
+        "node_modules/isows": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+            "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/wevm"
+                }
+            ],
+            "license": "MIT",
+            "peerDependencies": {
+                "ws": "*"
+            }
+        },
         "node_modules/iterator.prototype": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -4097,6 +5739,19 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/json-buffer": {
@@ -4319,6 +5974,13 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4333,6 +5995,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/lodash.lowercase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.lowercase/-/lodash.lowercase-4.3.0.tgz",
+            "integrity": "sha512-UcvP1IZYyDKyEL64mmrwoA1AbFu5ahojhTtkOUr1K9dbuxzS9ev8i4TxMMGCqRC9TE8uDaSoufNAXxRPNTseVA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -4399,6 +6068,24 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/meros": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.2.tgz",
+            "integrity": "sha512-Q3mobPbvEx7XbwhnC1J1r60+5H6EZyNccdzSz0eGexJRwouUtTZxPVRGdqKtxlpD84ScK4+tIGldkqDtCKdI0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=13"
+            },
+            "peerDependencies": {
+                "@types/node": ">=13"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                }
             }
         },
         "node_modules/micromatch": {
@@ -4480,6 +6167,27 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "license": "MIT"
         },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
         "node_modules/node-exports-info": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -4509,6 +6217,48 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/node-fetch": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "remove-trailing-separator": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/npm-normalize-package-bin": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-6.0.0.tgz",
@@ -4517,6 +6267,22 @@
             "license": "ISC",
             "engines": {
                 "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+            }
+        },
+        "node_modules/npm-package-arg": {
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
+            "integrity": "sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/npm-run-all2": {
@@ -4849,19 +6615,16 @@
             "license": "BlueOak-1.0.0"
         },
         "node_modules/package-json-validator": {
-            "version": "0.60.0",
-            "resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-0.60.0.tgz",
-            "integrity": "sha512-3BBkeFHm3O1VsazTSIN8+AGAl/eJQvTvWquECchRszIW6SC3aJ/fZHwZkpsmJlt7FMjTMNEgz+EhamVn94wgFw==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/package-json-validator/-/package-json-validator-1.5.2.tgz",
+            "integrity": "sha512-eHXskJQU4aCiSfjhRfTVtCJ+22/EzLHgYgZv5Gj3teb3NJrnTMzq5BnKAWKvR+PLpknCO1PmOCImDuO+dX4Vaw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "npm-package-arg": "^13.0.2",
                 "semver": "^7.7.2",
                 "validate-npm-package-license": "^3.0.4",
-                "validate-npm-package-name": "^7.0.0",
-                "yargs": "~18.0.0"
-            },
-            "bin": {
-                "pjv": "lib/bin/pjv.mjs"
+                "validate-npm-package-name": "^7.0.0"
             },
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -4878,6 +6641,32 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-json/node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -4918,6 +6707,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/picocolors": {
@@ -4998,6 +6797,16 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/proc-log": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+            "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/prop-types": {
@@ -5106,6 +6915,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/requireindex": {
             "version": "1.1.0",
@@ -5441,6 +7257,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/slash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/smol-toml": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -5533,23 +7359,12 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+        "node_modules/string-env-interpolation": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+            "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+            "license": "MIT"
         },
         "node_modules/string.prototype.matchall": {
             "version": "4.0.12",
@@ -5649,22 +7464,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/strip-ansi": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^6.2.2"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
         "node_modules/strip-bom": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -5712,6 +7511,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/sync-fetch": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.6.0.tgz",
+            "integrity": "sha512-IELLEvzHuCfc1uTsshPK58ViSdNqXxlml1U+fmwJIKLYKOr/rAtBrorE2RYm5IHaMpDNlmC0fr1LAvdXvyheEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "node-fetch": "^3.3.2",
+                "timeout-signal": "^2.0.0",
+                "whatwg-mimetype": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/synckit": {
             "version": "0.11.13",
             "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
@@ -5726,6 +7540,16 @@
             },
             "funding": {
                 "url": "https://opencollective.com/synckit"
+            }
+        },
+        "node_modules/timeout-signal": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/timeout-signal/-/timeout-signal-2.0.0.tgz",
+            "integrity": "sha512-YBGpG4bWsHoPvofT6y/5iqulfXIiIErl5B0LdtHT1mGXDFTAhhRrbUpTvBgYbovr+3cKblya2WAOcpoy90XguA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/tinyglobby": {
@@ -5896,16 +7720,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-            "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+            "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.60.1",
-                "@typescript-eslint/parser": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1"
+                "@typescript-eslint/eslint-plugin": "8.63.0",
+                "@typescript-eslint/parser": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5965,6 +7789,50 @@
                 "emoji-regex-xs": "^2.0.0"
             }
         },
+        "node_modules/unixify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+            "integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "normalize-path": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5973,6 +7841,13 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
+        },
+        "node_modules/urlpattern-polyfill": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+            "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
@@ -6003,6 +7878,26 @@
             "license": "ISC",
             "engines": {
                 "node": "20 || >=22"
+            }
+        },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/which": {
@@ -6118,46 +8013,34 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/wrap-ansi": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+        "node_modules/ws": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=12"
+                "node": ">=10.0.0"
             },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/y18n": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=10"
-            }
+            "license": "ISC"
         },
         "node_modules/yaml": {
             "version": "2.9.0",
@@ -6173,34 +8056,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/eemeli"
-            }
-        },
-        "node_modules/yargs": {
-            "version": "18.0.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^9.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "string-width": "^7.2.0",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^22.0.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=23"
-            }
-        },
-        "node_modules/yargs-parser": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/yocto-queue": {

--- a/create-app/package.json
+++ b/create-app/package.json
@@ -39,7 +39,7 @@
         "rimraf": "^6.1.3"
     },
     "devDependencies": {
-        "@comet/eslint-config": "^8.25.0",
+        "@comet/eslint-config": "9.1.0",
         "@tsconfig/node24": "^24.0.4",
         "@types/node": "^24.13.2",
         "knip": "^6.24.0",

--- a/create-app/package.json
+++ b/create-app/package.json
@@ -14,6 +14,7 @@
     "license": "BSD-2-Clause",
     "author": "Vivid Planet Software GmbH <office@vivid-planet.com> (https://www.vivid-planet.com/)",
     "bin": "./bin/index.js",
+    "sideEffects": false,
     "files": [
         "lib/**/*.js"
     ],

--- a/create-app/src/scripts/create-app/createApp.ts
+++ b/create-app/src/scripts/create-app/createApp.ts
@@ -31,12 +31,16 @@ export async function createApp(commandOptions: CreateAppCommandOptions) {
         try {
             execSync("sh ./install.sh");
             spinner.success();
-            if (commandOptions.verbose) console.log(kleur.grey("Successfully installed project."));
+            if (commandOptions.verbose) {
+                console.log(kleur.grey("Successfully installed project."));
+            }
             runEslintFix(commandOptions.verbose);
         } catch (error) {
             spinner.error();
             console.log(kleur.yellow("Could not install project."));
-            if (commandOptions.verbose) console.log(kleur.grey(`${error}`));
+            if (commandOptions.verbose) {
+                console.log(kleur.grey(`${error}`));
+            }
         }
     }
     amendCommitChanges();

--- a/create-app/src/scripts/create-app/createWorkingDirectoryCopy.ts
+++ b/create-app/src/scripts/create-app/createWorkingDirectoryCopy.ts
@@ -2,7 +2,7 @@ import { execSync } from "child_process";
 import kleur from "kleur";
 import process from "process";
 
-import { type CreateAppCommandOptions } from "./createApp";
+import type { CreateAppCommandOptions } from "./createApp";
 
 export function createWorkingDirectoryCopy({
     projectName,

--- a/create-app/src/util/replacePlaceholder.ts
+++ b/create-app/src/util/replacePlaceholder.ts
@@ -18,8 +18,11 @@ export function replacePlaceholder(projectName: string, verbose: boolean): void 
             const contents = fs.readFileSync(file, "utf8").toString();
 
             if (placeholder.test(contents)) {
-                if (file.endsWith("intl-update.sh")) fs.writeFileSync(file, contents.replaceAll("lang/starter-lang", `lang/${projectName}-lang`));
-                else fs.writeFileSync(file, contents.replaceAll(placeholder, projectName));
+                if (file.endsWith("intl-update.sh")) {
+                    fs.writeFileSync(file, contents.replaceAll("lang/starter-lang", `lang/${projectName}-lang`));
+                } else {
+                    fs.writeFileSync(file, contents.replaceAll(placeholder, projectName));
+                }
                 changedFiles++;
                 if (verbose) {
                     console.log(kleur.grey(`Replaced content in ${file}`));

--- a/create-app/src/util/runEslintFix.ts
+++ b/create-app/src/util/runEslintFix.ts
@@ -18,7 +18,9 @@ export function runEslintFix(verbose: boolean) {
         }
 
         try {
-            if (microservice !== "api") execSync(`npm --prefix ${microservice} run prelint`);
+            if (microservice !== "api") {
+                execSync(`npm --prefix ${microservice} run prelint`);
+            }
             execSync(`npm run --prefix ${microservice} lint:eslint -- --fix`);
         } catch (err) {
             console.log(kleur.yellow(`Failed to fix ESLint errors in ${microservice}.`));

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
         "": {
             "name": "starter",
             "devDependencies": {
-                "@comet/agent-features": "9.0.0-beta.5",
-                "@comet/cli": "9.0.0-beta.5",
+                "@comet/agent-features": "9.1.0",
+                "@comet/cli": "9.1.0",
                 "@comet/dev-oidc-provider": "^1.2.1",
                 "@comet/dev-process-manager": "^3.1.0",
                 "dotenv-cli": "^11.0.0",
@@ -47,16 +47,16 @@
             }
         },
         "node_modules/@comet/agent-features": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/agent-features/-/agent-features-9.0.0-beta.5.tgz",
-            "integrity": "sha512-+ybdk52IWYSUNsCoVx47oaYiDjgrryVh4DR+pez7ajTt820Z8MoyMHoL7mexlzLfBgMcIX4VuR/5Q3DQEPq+vQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/agent-features/-/agent-features-9.1.0.tgz",
+            "integrity": "sha512-WTThaKlBDKUZl1DIB+MNoXSmmGksZaIi+7Kj9+cF/F7P1/4i+gqVa/hHxmPdo2kTGomXPhRigAHdv4AV4fsbPg==",
             "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/@comet/cli": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/cli/-/cli-9.0.0-beta.5.tgz",
-            "integrity": "sha512-pf+4R978IX5sGLCOKhZjtV+KomDryjFHdNjVjDOjiqlW2cxwBtTSxkYfGSPfvoeIYvFN42V3Bq/WEJjub1W5BQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/cli/-/cli-9.1.0.tgz",
+            "integrity": "sha512-70F1IdhcaLh9bktn8c3FU+luG0ANIS5ntAunQyukGds0QeqW3sIPHhXlceaqUojY05uKCEFoPq3iiWQhTqzlog==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
         "setup:download-oauth2-proxy": "dotenv -- sh -c 'npx @comet/cli download-oauth2-proxy -v $OAUTH2_PROXY_VERSION'"
     },
     "devDependencies": {
-        "@comet/agent-features": "9.0.0-beta.5",
-        "@comet/cli": "9.0.0-beta.5",
+        "@comet/agent-features": "9.1.0",
+        "@comet/cli": "9.1.0",
         "@comet/dev-oidc-provider": "^1.2.1",
         "@comet/dev-process-manager": "^3.1.0",
         "dotenv-cli": "^11.0.0",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "starter-site",
             "dependencies": {
-                "@comet/site-nextjs": "9.0.0-beta.5",
+                "@comet/site-nextjs": "9.1.0",
                 "@fontsource/roboto": "^5.2.10",
                 "@next/bundle-analyzer": "^16.1.6",
                 "@opentelemetry/api": "^1.9.1",
@@ -29,8 +29,8 @@
                 "usehooks-ts": "^3.1.1"
             },
             "devDependencies": {
-                "@comet/cli": "9.0.0-beta.5",
-                "@comet/eslint-config": "9.0.0-beta.5",
+                "@comet/cli": "9.1.0",
+                "@comet/eslint-config": "9.1.0",
                 "@formatjs/cli": "^6.16.11",
                 "@graphql-codegen/add": "^7.0.1",
                 "@graphql-codegen/cli": "^7.1.3",
@@ -403,9 +403,9 @@
             }
         },
         "node_modules/@comet/cli": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/cli/-/cli-9.0.0-beta.5.tgz",
-            "integrity": "sha512-pf+4R978IX5sGLCOKhZjtV+KomDryjFHdNjVjDOjiqlW2cxwBtTSxkYfGSPfvoeIYvFN42V3Bq/WEJjub1W5BQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/cli/-/cli-9.1.0.tgz",
+            "integrity": "sha512-70F1IdhcaLh9bktn8c3FU+luG0ANIS5ntAunQyukGds0QeqW3sIPHhXlceaqUojY05uKCEFoPq3iiWQhTqzlog==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -422,18 +422,18 @@
             }
         },
         "node_modules/@comet/eslint-config": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/eslint-config/-/eslint-config-9.0.0-beta.5.tgz",
-            "integrity": "sha512-KbVm8A1TKAmNkwxUpwZZKJETTm230MWlMEMkLrWNiaWZFyX0zIzZ4a51kM9LIj/WqkF2Zs0kE+zfApUezmFGeg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/eslint-config/-/eslint-config-9.1.0.tgz",
+            "integrity": "sha512-gQK2nm7W8FBhLG4bnJfQXf3ufMB6D+qRya9m/3Q0jT7VJB+kA8bPhnvacH0ocQqNxeq0K/lVmkGFPHfjiiYMdw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@calm/eslint-plugin-react-intl": "^1.4.1",
-                "@comet/eslint-plugin": "9.0.0-beta.5",
+                "@comet/eslint-plugin": "9.1.0",
                 "@eslint/eslintrc": "^3.3.5",
                 "@eslint/js": "^9.39.4",
                 "@graphql-eslint/eslint-plugin": "^4.4.0",
-                "@next/eslint-plugin-next": "^16.2.6",
+                "@next/eslint-plugin-next": "^16.2.10",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-formatjs": "^5.4.2",
                 "eslint-plugin-import": "^2.32.0",
@@ -446,7 +446,7 @@
                 "eslint-plugin-unused-imports": "^4.4.1",
                 "globals": "^15.15.0",
                 "npm-run-all2": "^8.0.4",
-                "typescript-eslint": "^8.59.3"
+                "typescript-eslint": "^8.62.1"
             },
             "engines": {
                 "node": ">=22.0.0"
@@ -562,9 +562,9 @@
             }
         },
         "node_modules/@comet/eslint-plugin": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/eslint-plugin/-/eslint-plugin-9.0.0-beta.5.tgz",
-            "integrity": "sha512-XYuj83Q/WHrRnkUULeUo50jV13DZ+Xa2n7c5leatOdhSMj/xRDx7LjjMP21t2OHf4N75o8Fy9uyd38umbdcQFg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/eslint-plugin/-/eslint-plugin-9.1.0.tgz",
+            "integrity": "sha512-pkB8M69ITwDJC541WB0Z6wSZxfm05PqhQkzbCSWRFvd3Rl/QbGjLlt/Vy/lg7gZf35ZomVgHUeW0O5Vzevn6yQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -576,12 +576,12 @@
             }
         },
         "node_modules/@comet/site-nextjs": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/site-nextjs/-/site-nextjs-9.0.0-beta.5.tgz",
-            "integrity": "sha512-mWyo229yMcDD21EujEAe/P1xLGqg0b626v07Ou1kvhxInNqg83I8FdhGxUaC63NhiNiWTmucmT38q46Dlngw5g==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/site-nextjs/-/site-nextjs-9.1.0.tgz",
+            "integrity": "sha512-wQf1C1+RhcnieLTgrYytylca337mY3rDf/4Btl9KOYY+Jx0XOU8gguaf4G7+Lm9JfAb0IP6pCa5yQp6gdKj0XQ==",
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@comet/site-react": "9.0.0-beta.5",
+                "@comet/site-react": "9.1.0",
                 "jose": "^5.10.0",
                 "server-only": "^0.0.1"
             },
@@ -589,15 +589,15 @@
                 "node": ">=18.0.0"
             },
             "peerDependencies": {
-                "next": "^16.0.0",
-                "react": "^19.0.0",
-                "react-dom": "^19.0.0"
+                "next": "^14.2.0 || ^15.0.0 || ^16.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/@comet/site-react": {
-            "version": "9.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@comet/site-react/-/site-react-9.0.0-beta.5.tgz",
-            "integrity": "sha512-ufdrdo1+CQh1szAprryyIfuElEjZcs5ePxJz0gWZz48tQAhsDkB1Sb0pMpOeBTZfoKjVpemZ9WXO4VACqwLRbQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/@comet/site-react/-/site-react-9.1.0.tgz",
+            "integrity": "sha512-2jZsXoUuMQxXQWXbabEKPND/s9/c/xe6inyYSN4ve1Lb5sXcel3rCS/ZcmqXVnXLWtonOCyWoagbHy5/uAQSMQ==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "clsx": "^2.1.1",
@@ -3994,9 +3994,9 @@
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "16.2.7",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.7.tgz",
-            "integrity": "sha512-VbS+QgMHqvIDMTIqD2xMBKK1otIpdAUKA8VLHFwR9h6OfU/mOm7w/69nQcvdmI8hCk99Wr2AsGLn/PJ/tMHw1w==",
+            "version": "16.2.10",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.10.tgz",
+            "integrity": "sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6928,17 +6928,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-            "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+            "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/type-utils": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/type-utils": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -6951,7 +6951,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.60.1",
+                "@typescript-eslint/parser": "^8.63.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -6967,16 +6967,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-            "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+            "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -6992,14 +6992,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-            "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+            "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.60.1",
-                "@typescript-eslint/types": "^8.60.1",
+                "@typescript-eslint/tsconfig-utils": "^8.63.0",
+                "@typescript-eslint/types": "^8.63.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -7014,14 +7014,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-            "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+            "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1"
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7032,9 +7032,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-            "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+            "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7049,15 +7049,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-            "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+            "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -7074,9 +7074,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-            "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+            "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7088,16 +7088,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-            "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+            "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.60.1",
-                "@typescript-eslint/tsconfig-utils": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/visitor-keys": "8.60.1",
+                "@typescript-eslint/project-service": "8.63.0",
+                "@typescript-eslint/tsconfig-utils": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/visitor-keys": "8.63.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -7126,9 +7126,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7155,9 +7155,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-            "version": "7.8.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-            "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -7168,16 +7168,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-            "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+            "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.60.1",
-                "@typescript-eslint/types": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1"
+                "@typescript-eslint/scope-manager": "8.63.0",
+                "@typescript-eslint/types": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7192,13 +7192,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-            "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+            "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/types": "8.63.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -16136,16 +16136,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.60.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-            "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+            "version": "8.63.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+            "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.60.1",
-                "@typescript-eslint/parser": "8.60.1",
-                "@typescript-eslint/typescript-estree": "8.60.1",
-                "@typescript-eslint/utils": "8.60.1"
+                "@typescript-eslint/eslint-plugin": "8.63.0",
+                "@typescript-eslint/parser": "8.63.0",
+                "@typescript-eslint/typescript-estree": "8.63.0",
+                "@typescript-eslint/utils": "8.63.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/site/package.json
+++ b/site/package.json
@@ -29,7 +29,7 @@
         "setup:ci": "./intl-update.sh"
     },
     "dependencies": {
-        "@comet/site-nextjs": "9.0.0-beta.5",
+        "@comet/site-nextjs": "9.1.0",
         "@fontsource/roboto": "^5.2.10",
         "@next/bundle-analyzer": "^16.1.6",
         "@opentelemetry/api": "^1.9.1",
@@ -52,8 +52,8 @@
         "usehooks-ts": "^3.1.1"
     },
     "devDependencies": {
-        "@comet/cli": "9.0.0-beta.5",
-        "@comet/eslint-config": "9.0.0-beta.5",
+        "@comet/cli": "9.1.0",
+        "@comet/eslint-config": "9.1.0",
         "@formatjs/cli": "^6.16.11",
         "@graphql-codegen/add": "^7.0.1",
         "@graphql-codegen/cli": "^7.1.3",


### PR DESCRIPTION
Update Comet to 9.1.0. I ran the `/comet-major-migration`-skill to test whether any steps of the migration guide were still missing:

> **No gaps found.** Every applicable step is implemented in the code; every skipped step is a conditional one that doesn't apply to this project.
> Two things I did **not** run (they're process-level and slow/potentially sandbox-blocked): the `npm run lint` and `npm run test` verifications the guide prescribes per package. Want me to run those to confirm a fully green state, or dispatch the browser smoke test?

