### PR TITLE
Remove unused env files from lint:api-can-start command

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
         "fixtures": "npm run console fixtures --",
         "fixtures:prod": "npm run console:prod fixtures --",
         "lint": "npm run api-generator && run-p -l lint:{eslint,knip,prettier,tsc,api-can-start}",
-        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=$(echo '[]' | base64) dotenv -e ../.env.secrets -e ../.env.local -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
+        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=$(echo '[]' | base64) dotenv -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
         "lint:ci": "npm run lint && npm run lint:generated-files-not-modified",
         "lint:eslint": "eslint --max-warnings 0 src/ '**/*.json' --no-warn-ignored",
         "lint:fix": "run-p lint:fix:{eslint,prettier}",


### PR DESCRIPTION
Starter equivalent of https://github.com/vivid-planet/comet/pull/5986

`lint:api-can-start` is primarily meant to be run in the pipeline, so using `.env.local` and `.env.secrets` doesn't make sense.

In comet-starter's `api/package.json`, this maps to dropping `.env.secrets` and `.env.local` from the `dotenv -e` flags in `lint:api-can-start`, keeping `.env` (the starter doesn't use `.env.site-configs` here, since it derives `PRIVATE_SITE_CONFIGS` inline instead):

```diff
-        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=$(echo '[]' | base64) dotenv -e ../.env.secrets -e ../.env.local -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
+        "lint:api-can-start": "MIKRO_ORM_NO_CONNECT=true PRIVATE_SITE_CONFIGS=$(echo '[]' | base64) dotenv -e ../.env -- ts-node --transpile-only -r tsconfig-paths/register src/console.ts --help",
```

https://claude.ai/code/session_017pwmnn4MDZPD2um7HNKP2S


---
_Generated by [Claude Code](https://claude.ai/code/session_01LgNNF27qwK6xztNz1CbLqZ)_