### PR TITLE
Remove system user filter from AccessLogModule

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -138,7 +138,7 @@ export class AppModule {
                 ...(!config.debug
                     ? [
                           AccessLogModule.forRoot({
-                              shouldLogRequest: ({ user, req }) => user !== SYSTEM_USER_NAME && !req.route.path.startsWith("/api/healthcheck/"),
+                              shouldLogRequest: ({ req }) => !req.route.path.startsWith("/api/healthcheck/"),
                           }),
                       ]
                     : []),


### PR DESCRIPTION
Ports vivid-planet/comet#5994 to comet-starter.

## What

Removes the `system-user` filter from `AccessLogModule.forRoot()`'s `shouldLogRequest` in `api/src/app.module.ts`:

```diff
-shouldLogRequest: ({ user, req }) => user !== SYSTEM_USER_NAME && !req.route.path.startsWith("/api/healthcheck/"),
+shouldLogRequest: ({ req }) => !req.route.path.startsWith("/api/healthcheck/"),
```

## Why

The system-user filter was originally added to reduce logging noise caused by requests made during site builds. Since the site switched to server-side rendering (SSR), those requests are no longer made by the system user, so the filter is obsolete.

Healthcheck requests (`/api/healthcheck/`) continue to be excluded from access logs, and the module continues to be registered only when not in debug mode — both unchanged by this PR.

`SYSTEM_USER_NAME` is still imported and used elsewhere in `app.module.ts` (for `systemUsers`), so the import is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)