### PR TITLE
Skip auto assign for bot pull requests

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -7,6 +7,3 @@ reviewers:
 
 skipKeywords:
   - Merge main into next
-
-skipUsers:
-  - renovate[bot]

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   auto-assign:
+    # auto-assign-action has no option to skip pull requests based on their author,
+    # so bot pull requests (Renovate, Copilot, ...) are filtered out here.
+    if: github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.2


### PR DESCRIPTION
Starter equivalent of https://github.com/vivid-planet/comet/pull/6071

## Problem

Pull requests opened by Renovate still get a reviewer and an assignee added, even though `.github/auto_assign.yml` contains a `skipUsers` list naming it.

The reason is that `skipUsers` is not an option of `kentaro-m/auto-assign-action`. Its `Config` interface only supports `addReviewers`, `addAssignees`, `reviewers`, `assignees`, `filterLabels`, `numberOfAssignees`, `numberOfReviewers`, `skipKeywords`, `useReviewGroups`, `useAssigneeGroups`, `reviewGroups`, `assigneeGroups` and `runOnDraft` — no author-based filtering of any kind. The option doesn't exist in the pinned `v2.0.2` either, nor on the action's current `main` branch, so there is no version to upgrade to.

The action loads the configuration file with `yaml.safeLoad()` and passes the result straight through, so unknown keys are silently dropped — no warning, no failing job. The block looked plausible but was inert from the moment it was added.

## Solution

Because the action offers no author filtering at all, the skip has to happen one level up, in the workflow's job condition:

```yaml
jobs:
  auto-assign:
    # auto-assign-action has no option to skip pull requests based on their author,
    # so bot pull requests (Renovate, Copilot, ...) are filtered out here.
    if: github.event.pull_request.user.type != 'Bot'
```

Checking `user.type` rather than matching logins keeps the condition short and avoids hardcoding bot account names. It also covers `github-actions[bot]`, in addition to `renovate[bot]`.

The dead `skipUsers` block is removed from `.github/auto_assign.yml`. Leaving it in place would keep implying that the filtering happens there.

## Note on rollout

For `pull_request` events GitHub evaluates the workflow file from the base branch, so this takes effect for pull requests opened after it lands on `main`. It does not retroactively affect any bot pull requests that are currently open.

## Changeset

None — this only touches repo workflow/CI configuration, not an application package.

---
_Generated by [Claude Code](https://claude.ai/code/session_012qnF7V8jjDYP45Gu1K4jQt)_