### PR TITLE
Display only published pages in PageTreeIndexBlock

### DIFF
--- a/site/src/common/blocks/PageTreeIndexBlock.loader.ts
+++ b/site/src/common/blocks/PageTreeIndexBlock.loader.ts
@@ -36,6 +36,7 @@ export const loader = async ({ graphQLFetch, scope }: BlockLoaderOptions<PageTre
                 offset: currentCount,
                 limit: pageSize,
             },
+            { headers: { "x-include-invisible-content": "" } },
         );
 
         totalCount = paginatedPageTreeNodes.totalCount;


### PR DESCRIPTION
Starter equivalent of https://github.com/vivid-planet/comet/pull/6064

## Summary

The `PageTreeIndexBlock` should only ever list published pages, since it links to pages a visitor can actually open. In the preview, however, `graphQLFetch` sends `x-include-invisible-content: Pages:Unpublished` for every request, so the block's loader also received unpublished nodes and rendered links to them.

The loader now overrides that header with an empty value for its own request. Per-request headers are merged over the preview defaults in `createFetchWithDefaults`, and the API treats the empty header as "no invisible content", so `paginatedPageTreeNodes` returns published pages only — in the preview as well as on the live site.

```ts
const { paginatedPageTreeNodes } = await graphQLFetch<GQLPageTreeIndexDataQuery, GQLPageTreeIndexDataQueryVariables>(
    query,
    { scope, offset: currentCount, limit: pageSize },
    { headers: { "x-include-invisible-content": "" } },
);
```

## Translation notes

- Applied 1:1 to `site/src/common/blocks/PageTreeIndexBlock.loader.ts` (source: `demo/site/src/common/blocks/PageTreeIndexBlock.loader.ts`). The file was byte-identical between the two repos prior to this change, so the diff applies cleanly with no adaptation needed.
- Nothing was skipped — the source PR only touched this one file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jv35Khb3Gn34uauJdeaUy5)_