### PR TITLE
Migrate from @comet/dev-oidc-provider to dev-oidc-provider

### DIFF
--- a/dev-oidc-provider.config.mts
+++ b/dev-oidc-provider.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from "@comet/dev-oidc-provider";
+import { defineConfig } from "dev-oidc-provider";
 import { staticUsers } from "./api/src/auth/static-users";
 
 export default defineConfig({

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "devDependencies": {
                 "@comet/agent-features": "9.2.2",
                 "@comet/cli": "9.2.2",
-                "@comet/dev-oidc-provider": "^1.2.1",
+                "dev-oidc-provider": "^2.0.0",
                 "dev-process-manager": "^4.0.0",
                 "dotenv-cli": "^11.0.0",
                 "husky": "^9.1.7",
@@ -70,26 +70,6 @@
             },
             "engines": {
                 "node": ">=22.0.0"
-            }
-        },
-        "node_modules/@comet/dev-oidc-provider": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@comet/dev-oidc-provider/-/dev-oidc-provider-1.2.1.tgz",
-            "integrity": "sha512-+fL5srKQ3gIoSCIBZr1dMoZEEGeMh3WOI8pb63fuK5jiEwEjFagqxlS3GKNRk72FXTAQaypG0dftqU2a2sMXHQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "@koa/ejs": "^5.1.0",
-                "@koa/router": "^14.0.0",
-                "koa-body": "^6.0.1",
-                "oidc-provider": "^9.5.1",
-                "unconfig": "^7.3.3"
-            },
-            "bin": {
-                "dev-oidc-provider": "lib/run.js"
-            },
-            "engines": {
-                "node": ">=22"
             }
         },
         "node_modules/@cspotcode/source-map-support": {
@@ -1720,6 +1700,26 @@
                 "npm": "1.2.8000 || >= 1.4.16"
             }
         },
+        "node_modules/dev-oidc-provider": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dev-oidc-provider/-/dev-oidc-provider-2.0.0.tgz",
+            "integrity": "sha512-7GXMNWpHEMmNXwW6IxTbtGTiKReNX8+V2Y0z6uWEmpnTDHYzb0oZZBkgkOghf2YSPohpN+jXNZJehD98pHWc7Q==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@koa/ejs": "^5.1.0",
+                "@koa/router": "^14.0.0",
+                "koa-body": "^6.0.1",
+                "oidc-provider": "^9.8.6",
+                "unconfig": "^7.5.0"
+            },
+            "bin": {
+                "dev-oidc-provider": "lib/run.js"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
         "node_modules/dev-process-manager": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/dev-process-manager/-/dev-process-manager-4.0.0.tgz",
@@ -2796,9 +2796,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-            "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+            "version": "6.2.8",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+            "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2966,13 +2966,17 @@
             "license": "MIT"
         },
         "node_modules/koa/node_modules/media-typer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/koa/node_modules/type-is": {
@@ -3159,9 +3163,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "5.1.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-            "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.1.tgz",
+            "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
             "dev": true,
             "funding": [
                 {
@@ -3174,7 +3178,7 @@
                 "nanoid": "bin/nanoid.js"
             },
             "engines": {
-                "node": "^18 || >=20"
+                "node": "^22 || ^24 || >=26"
             }
         },
         "node_modules/negotiator": {
@@ -3277,31 +3281,31 @@
             }
         },
         "node_modules/oidc-provider": {
-            "version": "9.8.4",
-            "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-9.8.4.tgz",
-            "integrity": "sha512-i8qe+wvhUQ7BSj6DxssIFAdpREouuqK91j2jGdAN78NIxTB5rxvU4ZniXELhUHIM4mzABeSGlp5wE6WTa8CY1Q==",
+            "version": "9.11.2",
+            "resolved": "https://registry.npmjs.org/oidc-provider/-/oidc-provider-9.11.2.tgz",
+            "integrity": "sha512-Z7CZzWtBfcNMSaIoNJwHmEbla6h4mW73soOAJM4Qo9XDALMgQ1J+amMg/FBZJD1BHoec1KLL5BHFDkvlgeUZqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@koa/cors": "^5.0.0",
-                "@koa/router": "^15.5.0",
+                "@koa/router": "^15.7.0",
                 "debug": "^4.4.3",
                 "eta": "^4.6.0",
-                "jose": "^6.2.3",
+                "jose": "^6.2.8",
                 "jsesc": "^3.1.0",
                 "koa": "^3.2.1",
-                "nanoid": "^5.1.11",
+                "nanoid": "^6.0.0",
                 "quick-lru": "^7.3.0",
-                "raw-body": "^3.0.2"
+                "raw-body": "^4.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
         },
         "node_modules/oidc-provider/node_modules/@koa/router": {
-            "version": "15.6.0",
-            "resolved": "https://registry.npmjs.org/@koa/router/-/router-15.6.0.tgz",
-            "integrity": "sha512-iEOXlvGIBqSNkGXrg0XtMARAOm5zA24oedXxiTGEkrD4JgwVjfRDddCQvW1s4WEcwDYvyecRbf8BikXsuEEj8w==",
+            "version": "15.7.0",
+            "resolved": "https://registry.npmjs.org/@koa/router/-/router-15.7.0.tgz",
+            "integrity": "sha512-WaAlk4TOl/O0rhTpOR0l052gz03syPMmI6Pe2gd7v3ubjfv5UcSGcnb0Y/J5NNC/ln+5FiUqPJTc/a15I+XqAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3322,37 +3326,18 @@
                 }
             }
         },
-        "node_modules/oidc-provider/node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
         "node_modules/oidc-provider/node_modules/raw-body": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-4.0.0.tgz",
+            "integrity": "sha512-TMHtwexrgOt9VJ2E5JF9RO8mRXGNgC5wXvKkc5AVSJUt1L5gxvjg7eiCQl96EqUEpCWrnNEkCnbAplYtyuq1IA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "bytes": "~3.1.2",
-                "http-errors": "~2.0.1",
-                "iconv-lite": "~0.7.0",
-                "unpipe": "~1.0.0"
+                "bytes": "^3.1.2",
+                "http-errors": "^2.0.1"
             },
             "engines": {
-                "node": ">= 0.10"
+                "node": ">=22"
             }
         },
         "node_modules/on-finished": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "devDependencies": {
         "@comet/agent-features": "9.2.2",
         "@comet/cli": "9.2.2",
-        "@comet/dev-oidc-provider": "^1.2.1",
+        "dev-oidc-provider": "^2.0.0",
         "dev-process-manager": "^4.0.0",
         "dotenv-cli": "^11.0.0",
         "husky": "^9.1.7",


### PR DESCRIPTION
Starter equivalent of https://github.com/vivid-planet/comet/pull/6128

Migrates the project from `@comet/dev-oidc-provider` to `dev-oidc-provider` v2. Replaces all references to the old package with the new one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPtYfDsTtvYpyNG5AnfzH4)_